### PR TITLE
Include metrics for the given entity in the metrics API response.

### DIFF
--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -32,6 +32,14 @@ class Metrics
   alias :read_attribute_for_serialization :send
   attr_reader :group_by, :root, :time_period
 
+  def metrics
+    [
+      AggregatedCallsReceivedMetric.new(root, time_period),
+      AggregatedTransactionsReceivedMetric.new(root, time_period),
+      AggregatedTransactionsWithOutcomeMetric.new(root, time_period)
+    ]
+  end
+
   def metric_groups
     entities.map do |entity|
       MetricGroup.new(entity, [

--- a/app/serializers/metrics_serializer.rb
+++ b/app/serializers/metrics_serializer.rb
@@ -1,6 +1,7 @@
 class MetricsSerializer < ActiveModel::Serializer
   attribute :group_by
 
+  has_many :metrics
   has_many :metric_groups
 
   def group_by

--- a/spec/models/metrics_spec.rb
+++ b/spec/models/metrics_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Metrics, type: :model do
+  class FakeMetricsSubclass < Metrics
+    def self.valid_group_bys
+      ['default']
+    end
+  end
+
+  let(:root) { double(:root) }
+  let(:time_period) { instance_double(TimePeriod) }
+
+  subject(:metrics) { FakeMetricsSubclass.new(root, time_period: time_period) }
+
+  describe '#metrics' do
+    it 'returns aggregated metrics for the root object' do
+      calls_received_metric = instance_double(AggregatedCallsReceivedMetric)
+      expect(AggregatedCallsReceivedMetric).to receive(:new).with(root, time_period) { calls_received_metric }
+
+      transactions_received_metric = instance_double(AggregatedTransactionsReceivedMetric)
+      expect(AggregatedTransactionsReceivedMetric).to receive(:new).with(root, time_period) { transactions_received_metric }
+
+      transactions_with_outcome_metric = instance_double(AggregatedTransactionsWithOutcomeMetric)
+      expect(AggregatedTransactionsWithOutcomeMetric).to receive(:new).with(root, time_period) { transactions_with_outcome_metric }
+
+      expect(metrics.metrics).to match_array([calls_received_metric, transactions_received_metric, transactions_with_outcome_metric])
+    end
+  end
+end


### PR DESCRIPTION
Previously it was possible to fetch this data by passing in the
"group_by" parameter which was equivalent to the type of entity the
metrics were being requested for.

Now we include the metrics for the entity, and then all of the "metric
groups", specified by the "group_by" parameter.

If the entity type and the group by parameters are of equivalent types
then the data returned in the `metrics` and `metric_groups` will be
identical.