### PR TITLE
Refactoring to pass remaining lint steps.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*

--- a/app/importers/government_organisation_register/organisations.rb
+++ b/app/importers/government_organisation_register/organisations.rb
@@ -5,11 +5,11 @@ module GovernmentOrganisationRegister
     def on_complete(env)
       header = env[:response_headers]['Link']
       links = LinkHeader.parse(header).to_a
-      env[:links] = links.each.with_object({}) do |(uri, attributes), links|
+      env[:links] = links.each.with_object({}) do |(uri, attributes), link_rels|
         uri = URI.parse(uri)
         _, relationship = attributes.detect { |(key, _value)| key == 'rel' }
 
-        links[relationship.to_sym] = uri
+        link_rels[relationship.to_sym] = uri
       end
     end
   end


### PR DESCRIPTION
This also includes a configuration for rubocop to ignore
Metrics/BlockLength problems in specs as it is unrealistic to make the
outer RSpec.describe less than 25 lines.