### PR TITLE
Make quantity in transactions_received nullable

### DIFF
--- a/db/migrate/20170823152521_make_tx_recv_value_nullable.rb
+++ b/db/migrate/20170823152521_make_tx_recv_value_nullable.rb
@@ -1,0 +1,5 @@
+class MakeTxRecvValueNullable < ActiveRecord::Migration[5.0]
+  def change
+    change_column :transactions_received_metrics, :quantity, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170726094103) do
+ActiveRecord::Schema.define(version: 20170823152521) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 20170726094103) do
     t.date     "starts_on",                  null: false
     t.date     "ends_on",                    null: false
     t.string   "channel",                    null: false
-    t.bigint   "quantity",                   null: false
+    t.integer  "quantity"
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
   end


### PR DESCRIPTION
We need to be able to support a metric item having no value (aka null)
and so the field in the DB needs to be nullable.