### PR TITLE
Unflatten calls received metrics table

### DIFF
--- a/app/models/aggregated_calls_received_metric.rb
+++ b/app/models/aggregated_calls_received_metric.rb
@@ -14,14 +14,14 @@ class AggregatedCallsReceivedMetric
       .where(service_code: organisation.services.pluck(:natural_key))
       .where('starts_on >= ? AND ends_on <= ?', time_period.starts_on, time_period.ends_on)
       .each do |metric, _memo|
-        @total += metric.quantity
-        @get_information += metric.quantity_of_get_information || 0
-        @chase_progress += metric.quantity_of_chase_progress || 0
-        @challenge_a_decision += metric.quantity_of_challenge_a_decision || 0
-        @other += metric.quantity_of_other || 0
+        @total += metric.quantity if metric.item == 'total'
+        @get_information += metric.quantity if metric.item == 'get-information'
+        @chase_progress += metric.quantity if metric.item == 'chase-progress'
+        @challenge_a_decision += metric.quantity if metric.item == 'challenge-a-decision'
+        @other += metric.quantity if metric.item == 'other'
 
         @sampled |= metric.sampled
-        @sampled_total += metric.sample_size || metric.quantity
+        @sampled_total += metric.sample_size || metric.quantity if metric.item == 'total'
       end
   end
 

--- a/db/migrate/20170824083518_unflatten_calls_rx.rb
+++ b/db/migrate/20170824083518_unflatten_calls_rx.rb
@@ -1,0 +1,60 @@
+class UnflattenCallsRx < ActiveRecord::Migration[5.0]
+  def change
+    # Copy table
+    sql = "select * into tmp_calls_rx from calls_received_metrics;"
+    ActiveRecord::Base.connection.execute(sql)
+
+    remove_column :calls_received_metrics, :quantity_of_get_information
+    remove_column :calls_received_metrics, :quantity_of_chase_progress
+    remove_column :calls_received_metrics, :quantity_of_challenge_a_decision
+    remove_column :calls_received_metrics, :quantity_of_other
+
+    # Add new columns
+    add_column :calls_received_metrics, :item, :string, null: true
+
+    # Copy across data from tmp_calls_rx
+    CallsReceivedMetric.delete_all
+    sql = 'select * from tmp_calls_rx;'
+    records_array = ActiveRecord::Base.connection.execute(sql)
+    records_array.each{ |row|
+
+        quantity_of_other = row.delete('quantity_of_other')
+        quantity_of_get_information = row.delete('quantity_of_get_information')
+        quantity_of_chase_progress = row.delete('quantity_of_chase_progress')
+        quantity_of_challenge_a_decision = row.delete('quantity_of_challenge_a_decision')
+        quantity_total = row.delete('quantity')
+
+        row.delete('id')
+
+        t_other = CallsReceivedMetric.new(row)
+        t_other.item = 'other'
+        t_other.quantity = quantity_of_other
+        t_other.save!
+
+        t_get = CallsReceivedMetric.new(row)
+        t_get.item = 'get-information'
+        t_get.quantity = quantity_of_get_information
+        t_get.save!
+
+        t_chase = CallsReceivedMetric.new(row)
+        t_chase.item = 'chase-progress'
+        t_chase.quantity = quantity_of_chase_progress
+        t_chase.save!
+
+        t_challenge = CallsReceivedMetric.new(row)
+        t_challenge.item = 'challenge-a-decision'
+        t_challenge.quantity = quantity_of_challenge_a_decision
+        t_challenge.save!
+
+        t_total = CallsReceivedMetric.new(row)
+        t_total.item = 'total'
+        t_total.quantity = quantity_total
+        t_total.save!
+    }
+
+    drop_table :tmp_calls_rx
+    change_column :calls_received_metrics, :quantity, :integer, null: true
+    change_column :calls_received_metrics, :item, :string, null: false
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,26 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170823152521) do
+ActiveRecord::Schema.define(version: 20170824083518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "calls_received_metrics", force: :cascade do |t|
-    t.string   "department_code",                  null: false
+    t.string   "department_code",            null: false
     t.string   "delivery_organisation_code"
-    t.string   "service_code",                     null: false
-    t.date     "starts_on",                        null: false
-    t.date     "ends_on",                          null: false
-    t.bigint   "quantity",                         null: false
-    t.boolean  "sampled",                          null: false
+    t.string   "service_code",               null: false
+    t.date     "starts_on",                  null: false
+    t.date     "ends_on",                    null: false
+    t.integer  "quantity"
+    t.boolean  "sampled",                    null: false
     t.integer  "sample_size"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.integer  "quantity_of_get_information"
-    t.integer  "quantity_of_chase_progress"
-    t.integer  "quantity_of_challenge_a_decision"
-    t.integer  "quantity_of_other"
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "item",                       null: false
   end
 
   create_table "delivery_organisations", force: :cascade do |t|
@@ -67,6 +64,24 @@ ActiveRecord::Schema.define(version: 20170823152521) do
     t.string   "start_page_url"
     t.string   "paper_form_url"
     t.index ["natural_key"], name: "index_services_on_natural_key", unique: true, using: :btree
+  end
+
+  create_table "tmp_calls_rx", id: false, force: :cascade do |t|
+    t.integer  "id"
+    t.string   "department_code"
+    t.string   "delivery_organisation_code"
+    t.string   "service_code"
+    t.date     "starts_on"
+    t.date     "ends_on"
+    t.bigint   "quantity"
+    t.boolean  "sampled"
+    t.integer  "sample_size"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "quantity_of_get_information"
+    t.integer  "quantity_of_chase_progress"
+    t.integer  "quantity_of_challenge_a_decision"
+    t.integer  "quantity_of_other"
   end
 
   create_table "transactions_received_metrics", force: :cascade do |t|

--- a/spec/models/aggregated_calls_received_metric_spec.rb
+++ b/spec/models/aggregated_calls_received_metric_spec.rb
@@ -5,23 +5,32 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
     specify 'for a given department' do
       department = FactoryGirl.create(:department)
       service1 = FactoryGirl.create(:service, department: department)
-      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-01-01', ends_on: '2017-01-31', quantity: 50, quantity_of_get_information: 45)
-      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-02-01', ends_on: '2017-02-28', quantity: 60, quantity_of_get_information: 55)
-      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-03-01', ends_on: '2017-03-31', quantity: 70, quantity_of_get_information: 65)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 50)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: 45)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'total', quantity: 60)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'get-information', quantity: 55)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'total', quantity: 70)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'get-information', quantity: 65)
 
       service2 = FactoryGirl.create(:service, department: department)
-      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-01-01', ends_on: '2017-01-31', quantity: 50, quantity_of_get_information: 45)
-      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-02-28', quantity: 60, quantity_of_get_information: 55)
-      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-03-01', ends_on: '2017-03-31', quantity: 70, quantity_of_get_information: 65)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 50)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: 45)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'total', quantity: 60)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'get-information', quantity: 55)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'total', quantity: 70)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'get-information', quantity: 65)
 
       # ignores metrics with overlapping ranges
-      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2016-12-01', ends_on: '2017-01-31', quantity: 30, quantity_of_get_information: 25)
-      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-04-30', quantity: 20, quantity_of_get_information: 15)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2016-12-01', ends_on: '2017-01-31', item: 'total', quantity: 30)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2016-12-01', ends_on: '2017-01-31', item: 'get-information', quantity: 25)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-04-30', item: 'total', quantity: 20)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-04-30', item: 'get-information', quantity: 15)
 
       # ignores metrics for services, in other departments
       other_department = FactoryGirl.create(:department)
       other_service = FactoryGirl.create(:service, department: other_department)
-      FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', quantity: 10, quantity_of_get_information: 5)
+      FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 10)
+      FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: 5)
 
       time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
       metric = AggregatedCallsReceivedMetric.new(department, time_period)
@@ -35,23 +44,34 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
     specify 'for a given delivery_organisation' do
       delivery_organisation = FactoryGirl.create(:delivery_organisation)
       service1 = FactoryGirl.create(:service, delivery_organisation: delivery_organisation)
-      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-01-01', ends_on: '2017-01-31', quantity: 50, quantity_of_get_information: 45)
-      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-02-01', ends_on: '2017-02-28', quantity: 60, quantity_of_get_information: 55)
-      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-03-01', ends_on: '2017-03-31', quantity: 70, quantity_of_get_information: 65)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 50)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: 45)
+
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'total', quantity: 60)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'get-information', quantity: 55)
+
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'total', quantity: 70)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'get-information', quantity: 65)
 
       service2 = FactoryGirl.create(:service, delivery_organisation: delivery_organisation)
-      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-01-01', ends_on: '2017-01-31', quantity: 50, quantity_of_get_information: 45)
-      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-02-28', quantity: 60, quantity_of_get_information: 55)
-      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-03-01', ends_on: '2017-03-31', quantity: 70, quantity_of_get_information: 65)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 50)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: 45)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'total', quantity: 60)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'get-information', quantity: 55)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'total', quantity: 70)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'get-information', quantity: 65)
 
       # ignores metrics with overlapping ranges
-      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2016-12-01', ends_on: '2017-01-31', quantity: 30, quantity_of_get_information: 25)
-      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-04-30', quantity: 20, quantity_of_get_information: 15)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2016-12-01', ends_on: '2017-01-31', item: 'total', quantity: 30)
+      FactoryGirl.create(:calls_received_metric, service: service1, starts_on: '2016-12-01', ends_on: '2017-01-31', item: 'get-information', quantity: 25)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-04-30', item: 'total', quantity: 20)
+      FactoryGirl.create(:calls_received_metric, service: service2, starts_on: '2017-02-01', ends_on: '2017-04-30', item: 'get-information', quantity: 15)
 
       # ignores metrics for services, in other departments
       other_delivery_organisation = FactoryGirl.create(:delivery_organisation)
       other_service = FactoryGirl.create(:service, delivery_organisation: other_delivery_organisation)
-      FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', quantity: 10, quantity_of_get_information: 5)
+      FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 10)
+      FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: 5)
 
       time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
       metric = AggregatedCallsReceivedMetric.new(delivery_organisation, time_period)
@@ -64,17 +84,23 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
 
     specify 'for a given service' do
       service = FactoryGirl.create(:service)
-      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', quantity: 50, quantity_of_get_information: 45)
-      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-02-28', quantity: 60, quantity_of_get_information: 55)
-      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-03-01', ends_on: '2017-03-31', quantity: 70, quantity_of_get_information: 65)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 50)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: 45)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'total', quantity: 60)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'get-information', quantity: 55)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'total', quantity: 70)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'get-information', quantity: 65)
 
       # ignores metrics with overlapping ranges
-      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2016-12-01', ends_on: '2017-01-31', quantity: 30, quantity_of_get_information: 25)
-      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-04-30', quantity: 20, quantity_of_get_information: 15)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2016-12-01', ends_on: '2017-01-31', item: 'total', quantity: 30)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2016-12-01', ends_on: '2017-01-31', item: 'get-information', quantity: 25)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-04-30', item: 'total', quantity: 20)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-04-30', item: 'get-information', quantity: 15)
 
       # ignores metrics for other services
       other_service = FactoryGirl.create(:service)
-      FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', quantity: 10, quantity_of_get_information: 5)
+      FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 10)
+      FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: 5)
 
       time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
       metric = AggregatedCallsReceivedMetric.new(service, time_period)
@@ -88,9 +114,9 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
     context 'aggregating sampled & non-sampled data' do
       it 'is sampled if any of the metrics are sampled' do
         service = FactoryGirl.create(:service)
-        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', quantity: 50, sampled: false)
-        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-02-28', quantity: 60, sampled: true, sample_size: 15)
-        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-03-01', ends_on: '2017-03-31', quantity: 70, sampled: false)
+        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 50, sampled: false)
+        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'total', quantity: 60, sampled: true, sample_size: 15)
+        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'total', quantity: 70, sampled: false)
 
         time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
         metric = AggregatedCallsReceivedMetric.new(service, time_period)
@@ -101,9 +127,9 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
 
       it "isn't sampled if none of the metrics are sampled" do
         service = FactoryGirl.create(:service)
-        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', quantity: 50, sampled: false)
-        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-02-28', quantity: 60, sampled: false)
-        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-03-01', ends_on: '2017-03-31', quantity: 70, sampled: false)
+        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 50, sampled: false)
+        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'total', quantity: 60, sampled: false)
+        FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'total', quantity: 70, sampled: false)
 
         time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
         metric = AggregatedCallsReceivedMetric.new(service, time_period)


### PR DESCRIPTION
Unflattens the calls_received_metrics table to provide a row per metric
item instead of all metric items in a single row.  This will allow us to
represent missing metric item values as well as non-applicable metric
items.