### PR TITLE
Returns null for n/a metric items

### DIFF
--- a/app/models/aggregated_calls_received_metric.rb
+++ b/app/models/aggregated_calls_received_metric.rb
@@ -2,29 +2,42 @@ class AggregatedCallsReceivedMetric
   alias :read_attribute_for_serialization :send
 
   def initialize(organisation, time_period)
-    @total = 0
-    @get_information = 0
-    @chase_progress = 0
-    @challenge_a_decision = 0
-    @other = 0
     @sampled = false
-    @sampled_total = 0
-
-    CallsReceivedMetric
+    @totals = CallsReceivedMetric
       .where(service_code: organisation.services.pluck(:natural_key))
       .where('starts_on >= ? AND ends_on <= ?', time_period.starts_on, time_period.ends_on)
-      .each do |metric, _memo|
-        @total += metric.quantity || 0 if metric.item == 'total'
-        @get_information += metric.quantity || 0 if metric.item == 'get-information'
-        @chase_progress += metric.quantity || 0 if metric.item == 'chase-progress'
-        @challenge_a_decision += metric.quantity || 0 if metric.item == 'challenge-a-decision'
-        @other += metric.quantity || 0 if metric.item == 'other'
-
+      .each.with_object({}) do |metric, memo|
+        memo[metric.item] ||= 0
+        memo[metric.item] += metric.quantity
+        memo['sampled-total'] ||= 0
+        memo['sampled-total'] += metric.sample_size || metric.quantity || 0
         @sampled |= metric.sampled
-        @sampled_total += metric.sample_size || metric.quantity || 0 if metric.item == 'total'
       end
   end
 
-  attr_reader :total, :get_information, :chase_progress, :challenge_a_decision, :other,
-              :sampled, :sampled_total
+  def total
+    @totals['total']
+  end
+
+  def get_information
+    @totals['get-information']
+  end
+
+  def chase_progress
+    @totals['chase-progress']
+  end
+
+  def challenge_a_decision
+    @totals['challenge-a-decision']
+  end
+
+  def other
+    @totals['other']
+  end
+
+  def sampled_total
+    @totals['sampled-total']
+  end
+
+  attr_reader :sampled
 end

--- a/app/models/aggregated_transactions_received_metric.rb
+++ b/app/models/aggregated_transactions_received_metric.rb
@@ -12,26 +12,26 @@ class AggregatedTransactionsReceivedMetric
   end
 
   def total
-    online + phone + paper + face_to_face + other
+    [online, phone, paper, face_to_face, other].compact.sum
   end
 
   def online
-    @totals['online'] || 0
+    @totals['online']
   end
 
   def phone
-    @totals['phone'] || 0
+    @totals['phone']
   end
 
   def paper
-    @totals['paper'] || 0
+    @totals['paper']
   end
 
   def face_to_face
-    @totals['face_to_face'] || 0
+    @totals['face_to_face']
   end
 
   def other
-    @totals['other'] || 0
+    @totals['other']
   end
 end

--- a/spec/models/aggregated_calls_received_metric_spec.rb
+++ b/spec/models/aggregated_calls_received_metric_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       metric = AggregatedCallsReceivedMetric.new(department, time_period)
       expect(metric.total).to eq(360)
       expect(metric.get_information).to eq(330)
-      expect(metric.chase_progress).to eq(nil)
-      expect(metric.challenge_a_decision).to eq(nil)
-      expect(metric.other).to eq(nil)
+      expect(metric.chase_progress).to be_nil
+      expect(metric.challenge_a_decision).to be_nil
+      expect(metric.other).to be_nil
     end
 
     specify 'for a given delivery_organisation' do
@@ -77,9 +77,9 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       metric = AggregatedCallsReceivedMetric.new(delivery_organisation, time_period)
       expect(metric.total).to eq(360)
       expect(metric.get_information).to eq(330)
-      expect(metric.chase_progress).to eq(nil)
-      expect(metric.challenge_a_decision).to eq(nil)
-      expect(metric.other).to eq(nil)
+      expect(metric.chase_progress).to be_nil
+      expect(metric.challenge_a_decision).to be_nil
+      expect(metric.other).to be_nil
     end
 
     specify 'for a given service' do
@@ -106,9 +106,9 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       metric = AggregatedCallsReceivedMetric.new(service, time_period)
       expect(metric.total).to eq(180)
       expect(metric.get_information).to eq(165)
-      expect(metric.chase_progress).to eq(nil)
-      expect(metric.challenge_a_decision).to eq(nil)
-      expect(metric.other).to eq(nil)
+      expect(metric.chase_progress).to be_nil
+      expect(metric.challenge_a_decision).to be_nil
+      expect(metric.other).to be_nil
     end
 
     context 'aggregating sampled & non-sampled data' do

--- a/spec/models/aggregated_calls_received_metric_spec.rb
+++ b/spec/models/aggregated_calls_received_metric_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       metric = AggregatedCallsReceivedMetric.new(department, time_period)
       expect(metric.total).to eq(360)
       expect(metric.get_information).to eq(330)
-      expect(metric.chase_progress).to eq(0)
-      expect(metric.challenge_a_decision).to eq(0)
-      expect(metric.other).to eq(0)
+      expect(metric.chase_progress).to eq(nil)
+      expect(metric.challenge_a_decision).to eq(nil)
+      expect(metric.other).to eq(nil)
     end
 
     specify 'for a given delivery_organisation' do
@@ -77,9 +77,9 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       metric = AggregatedCallsReceivedMetric.new(delivery_organisation, time_period)
       expect(metric.total).to eq(360)
       expect(metric.get_information).to eq(330)
-      expect(metric.chase_progress).to eq(0)
-      expect(metric.challenge_a_decision).to eq(0)
-      expect(metric.other).to eq(0)
+      expect(metric.chase_progress).to eq(nil)
+      expect(metric.challenge_a_decision).to eq(nil)
+      expect(metric.other).to eq(nil)
     end
 
     specify 'for a given service' do
@@ -106,9 +106,9 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       metric = AggregatedCallsReceivedMetric.new(service, time_period)
       expect(metric.total).to eq(180)
       expect(metric.get_information).to eq(165)
-      expect(metric.chase_progress).to eq(0)
-      expect(metric.challenge_a_decision).to eq(0)
-      expect(metric.other).to eq(0)
+      expect(metric.chase_progress).to eq(nil)
+      expect(metric.challenge_a_decision).to eq(nil)
+      expect(metric.other).to eq(nil)
     end
 
     context 'aggregating sampled & non-sampled data' do

--- a/spec/models/aggregated_transactions_received_metric_spec.rb
+++ b/spec/models/aggregated_transactions_received_metric_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       expect(metric.total).to eq(2200)
       expect(metric.online).to eq(1200)
       expect(metric.phone).to eq(1000)
-      expect(metric.paper).to eq(nil)
-      expect(metric.face_to_face).to eq(nil)
-      expect(metric.other).to eq(nil)
+      expect(metric.paper).to be_nil
+      expect(metric.face_to_face).to be_nil
+      expect(metric.other).to be_nil
     end
 
     specify 'for a given delivery organisation' do
@@ -65,9 +65,9 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       expect(metric.total).to eq(2200)
       expect(metric.online).to eq(1200)
       expect(metric.phone).to eq(1000)
-      expect(metric.paper).to eq(nil)
-      expect(metric.face_to_face).to eq(nil)
-      expect(metric.other).to eq(nil)
+      expect(metric.paper).to be_nil
+      expect(metric.face_to_face).to be_nil
+      expect(metric.other).to be_nil
     end
 
     specify 'for a given service' do
@@ -90,9 +90,9 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       expect(metric.total).to eq(1100)
       expect(metric.online).to eq(600)
       expect(metric.phone).to eq(500)
-      expect(metric.paper).to eq(nil)
-      expect(metric.face_to_face).to eq(nil)
-      expect(metric.other).to eq(nil)
+      expect(metric.paper).to be_nil
+      expect(metric.face_to_face).to be_nil
+      expect(metric.other).to be_nil
     end
   end
 end

--- a/spec/models/aggregated_transactions_received_metric_spec.rb
+++ b/spec/models/aggregated_transactions_received_metric_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       expect(metric.total).to eq(2200)
       expect(metric.online).to eq(1200)
       expect(metric.phone).to eq(1000)
-      expect(metric.paper).to eq(0)
-      expect(metric.face_to_face).to eq(0)
-      expect(metric.other).to eq(0)
+      expect(metric.paper).to eq(nil)
+      expect(metric.face_to_face).to eq(nil)
+      expect(metric.other).to eq(nil)
     end
 
     specify 'for a given delivery organisation' do
@@ -65,9 +65,9 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       expect(metric.total).to eq(2200)
       expect(metric.online).to eq(1200)
       expect(metric.phone).to eq(1000)
-      expect(metric.paper).to eq(0)
-      expect(metric.face_to_face).to eq(0)
-      expect(metric.other).to eq(0)
+      expect(metric.paper).to eq(nil)
+      expect(metric.face_to_face).to eq(nil)
+      expect(metric.other).to eq(nil)
     end
 
     specify 'for a given service' do
@@ -90,9 +90,9 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       expect(metric.total).to eq(1100)
       expect(metric.online).to eq(600)
       expect(metric.phone).to eq(500)
-      expect(metric.paper).to eq(0)
-      expect(metric.face_to_face).to eq(0)
-      expect(metric.other).to eq(0)
+      expect(metric.paper).to eq(nil)
+      expect(metric.face_to_face).to eq(nil)
+      expect(metric.other).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
If a metric item is not applicable (not present) then this PR will
return the value as null rather than 0.

It changes the Aggregated call rx metrics items to follow the same pattern as
the aggregated trxn rx metric items.