### PR TITLE
Exclude metrics from response when no items

### DIFF
--- a/app/models/aggregated_calls_received_metric.rb
+++ b/app/models/aggregated_calls_received_metric.rb
@@ -17,6 +17,10 @@ class AggregatedCallsReceivedMetric
       end
   end
 
+  def is_applicable?
+    @totals.size.positive?
+  end
+
   def total
     @totals['total']
   end

--- a/app/models/aggregated_calls_received_metric.rb
+++ b/app/models/aggregated_calls_received_metric.rb
@@ -3,7 +3,7 @@ class AggregatedCallsReceivedMetric
 
   def initialize(organisation, time_period)
     @sampled = false
-    @totals = CallsReceivedMetric
+    @channels = CallsReceivedMetric
       .where(service_code: organisation.services.pluck(:natural_key))
       .where('starts_on >= ? AND ends_on <= ?', time_period.starts_on, time_period.ends_on)
       .each.with_object({}) do |metric, memo|
@@ -17,32 +17,32 @@ class AggregatedCallsReceivedMetric
       end
   end
 
-  def is_applicable?
-    @totals.size.positive?
+  def applicable?
+    @channels.any?
   end
 
   def total
-    @totals['total']
+    @channels['total']
   end
 
   def get_information
-    @totals['get-information']
+    @channels['get-information']
   end
 
   def chase_progress
-    @totals['chase-progress']
+    @channels['chase-progress']
   end
 
   def challenge_a_decision
-    @totals['challenge-a-decision']
+    @channels['challenge-a-decision']
   end
 
   def other
-    @totals['other']
+    @channels['other']
   end
 
   def sampled_total
-    @totals['sampled-total']
+    @channels['sampled-total']
   end
 
   attr_reader :sampled

--- a/app/models/aggregated_transactions_received_metric.rb
+++ b/app/models/aggregated_transactions_received_metric.rb
@@ -11,6 +11,10 @@ class AggregatedTransactionsReceivedMetric
       end
   end
 
+  def is_applicable?
+    @totals.size.positive?
+  end
+
   def total
     [online, phone, paper, face_to_face, other].compact.sum
   end

--- a/app/models/aggregated_transactions_received_metric.rb
+++ b/app/models/aggregated_transactions_received_metric.rb
@@ -6,8 +6,10 @@ class AggregatedTransactionsReceivedMetric
       .where(service_code: organisation.services.pluck(:natural_key))
       .where('starts_on >= ? AND ends_on <= ?', time_period.starts_on, time_period.ends_on)
       .each.with_object({}) do |metric, memo|
-        memo[metric.channel] ||= 0
-        memo[metric.channel] += metric.quantity
+        if metric.quantity.present?
+          memo[metric.channel] ||= 0
+          memo[metric.channel] += metric.quantity
+        end
       end
   end
 

--- a/app/models/aggregated_transactions_received_metric.rb
+++ b/app/models/aggregated_transactions_received_metric.rb
@@ -2,7 +2,7 @@ class AggregatedTransactionsReceivedMetric
   alias :read_attribute_for_serialization :send
 
   def initialize(organisation, time_period)
-    @totals = TransactionsReceivedMetric
+    @channels = TransactionsReceivedMetric
       .where(service_code: organisation.services.pluck(:natural_key))
       .where('starts_on >= ? AND ends_on <= ?', time_period.starts_on, time_period.ends_on)
       .each.with_object({}) do |metric, memo|
@@ -11,8 +11,8 @@ class AggregatedTransactionsReceivedMetric
       end
   end
 
-  def is_applicable?
-    @totals.size.positive?
+  def applicable?
+    @channels.any?
   end
 
   def total
@@ -20,22 +20,22 @@ class AggregatedTransactionsReceivedMetric
   end
 
   def online
-    @totals['online']
+    @channels['online']
   end
 
   def phone
-    @totals['phone']
+    @channels['phone']
   end
 
   def paper
-    @totals['paper']
+    @channels['paper']
   end
 
   def face_to_face
-    @totals['face_to_face']
+    @channels['face_to_face']
   end
 
   def other
-    @totals['other']
+    @channels['other']
   end
 end

--- a/app/models/aggregated_transactions_with_outcome_metric.rb
+++ b/app/models/aggregated_transactions_with_outcome_metric.rb
@@ -2,7 +2,7 @@ class AggregatedTransactionsWithOutcomeMetric
   alias :read_attribute_for_serialization :send
 
   def initialize(organisation, time_period)
-    @totals = TransactionsWithOutcomeMetric
+    @items = TransactionsWithOutcomeMetric
       .where(service_code: organisation.services.pluck(:natural_key))
       .where('starts_on >= ? AND ends_on <= ?', time_period.starts_on, time_period.ends_on)
       .each.with_object(total: 0, with_intended_outcome: 0) do |metric, memo|
@@ -11,15 +11,15 @@ class AggregatedTransactionsWithOutcomeMetric
       end
   end
 
-  def is_applicable?
-    @totals.size.positive?
+  def applicable?
+    @items.any?
   end
 
   def total
-    @totals[:total]
+    @items[:total]
   end
 
   def with_intended_outcome
-    @totals[:with_intended_outcome]
+    @items[:with_intended_outcome]
   end
 end

--- a/app/models/aggregated_transactions_with_outcome_metric.rb
+++ b/app/models/aggregated_transactions_with_outcome_metric.rb
@@ -11,6 +11,10 @@ class AggregatedTransactionsWithOutcomeMetric
       end
   end
 
+  def is_applicable?
+    @totals.size.positive?
+  end
+
   def total
     @totals[:total]
   end

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -38,7 +38,7 @@ class Metrics
       AggregatedCallsReceivedMetric.new(entity, time_period),
       AggregatedTransactionsReceivedMetric.new(entity, time_period),
       AggregatedTransactionsWithOutcomeMetric.new(entity, time_period)
-    ].compact.select(&:applicable?)
+    ].select(&:applicable?)
   end
 
   def metric_groups

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -33,22 +33,19 @@ class Metrics
   alias :read_attribute_for_serialization :send
   attr_reader :group_by, :root, :time_period
 
-  def metrics(entity: root)
+  def totals(entity: root)
     [
-      AggregatedCallsReceivedMetric,
-      AggregatedTransactionsReceivedMetric,
-      AggregatedTransactionsWithOutcomeMetric
-    ].map { |metric|
-      m = metric.new(entity, time_period)
-      m if m && m.is_applicable?
-    }.compact
+      AggregatedCallsReceivedMetric.new(entity, time_period),
+      AggregatedTransactionsReceivedMetric.new(entity, time_period),
+      AggregatedTransactionsWithOutcomeMetric.new(entity, time_period)
+    ].compact.select(&:applicable?)
   end
 
   def metric_groups
     entities.map { |entity|
-      m = metrics(entity: entity)
+      m = totals(entity: entity)
       MetricGroup.new(entity, m)
-    }.compact
+    }
   end
 
 private

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -33,22 +33,22 @@ class Metrics
   alias :read_attribute_for_serialization :send
   attr_reader :group_by, :root, :time_period
 
-  def metrics
+  def metrics(entity: root)
     [
-      AggregatedCallsReceivedMetric.new(root, time_period),
-      AggregatedTransactionsReceivedMetric.new(root, time_period),
-      AggregatedTransactionsWithOutcomeMetric.new(root, time_period)
-    ]
+      AggregatedCallsReceivedMetric,
+      AggregatedTransactionsReceivedMetric,
+      AggregatedTransactionsWithOutcomeMetric
+    ].map { |metric|
+      m = metric.new(entity, time_period)
+      m if m && m.is_applicable?
+    }.compact
   end
 
   def metric_groups
-    entities.map do |entity|
-      MetricGroup.new(entity, [
-        AggregatedCallsReceivedMetric.new(entity, time_period),
-        AggregatedTransactionsReceivedMetric.new(entity, time_period),
-        AggregatedTransactionsWithOutcomeMetric.new(entity, time_period)
-      ])
-    end
+    entities.map { |entity|
+      m = metrics(entity: entity)
+      MetricGroup.new(entity, m)
+    }.compact
   end
 
 private

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -33,7 +33,7 @@ class Metrics
   alias :read_attribute_for_serialization :send
   attr_reader :group_by, :root, :time_period
 
-  def totals(entity: root)
+  def metrics(entity: root)
     [
       AggregatedCallsReceivedMetric.new(entity, time_period),
       AggregatedTransactionsReceivedMetric.new(entity, time_period),
@@ -43,7 +43,7 @@ class Metrics
 
   def metric_groups
     entities.map { |entity|
-      m = totals(entity: entity)
+      m = metrics(entity: entity)
       MetricGroup.new(entity, m)
     }
   end

--- a/app/serializers/metrics_serializer.rb
+++ b/app/serializers/metrics_serializer.rb
@@ -1,7 +1,7 @@
 class MetricsSerializer < ActiveModel::Serializer
   attribute :group_by
 
-  has_many :totals
+  has_many :metrics
   has_many :metric_groups
 
   def group_by

--- a/app/serializers/metrics_serializer.rb
+++ b/app/serializers/metrics_serializer.rb
@@ -1,7 +1,7 @@
 class MetricsSerializer < ActiveModel::Serializer
   attribute :group_by
 
-  has_many :metrics
+  has_many :totals
   has_many :metric_groups
 
   def group_by

--- a/spec/models/metrics_spec.rb
+++ b/spec/models/metrics_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Metrics, type: :model do
       expect(AggregatedTransactionsWithOutcomeMetric).to receive(:new).with(root, time_period) { transactions_with_outcome_metric }
       expect(transactions_with_outcome_metric).to receive(:applicable?) { true }
 
-      expect(metrics.totals).to match_array([calls_received_metric, transactions_received_metric, transactions_with_outcome_metric])
+      expect(metrics.metrics).to match_array([calls_received_metric, transactions_received_metric, transactions_with_outcome_metric])
     end
   end
 end

--- a/spec/models/metrics_spec.rb
+++ b/spec/models/metrics_spec.rb
@@ -16,17 +16,17 @@ RSpec.describe Metrics, type: :model do
     it 'returns aggregated metrics for the root object' do
       calls_received_metric = instance_double(AggregatedCallsReceivedMetric)
       expect(AggregatedCallsReceivedMetric).to receive(:new).with(root, time_period) { calls_received_metric }
-      expect(calls_received_metric).to receive(:is_applicable?) { true }
+      expect(calls_received_metric).to receive(:applicable?) { true }
 
       transactions_received_metric = instance_double(AggregatedTransactionsReceivedMetric)
       expect(AggregatedTransactionsReceivedMetric).to receive(:new).with(root, time_period) { transactions_received_metric }
-      expect(transactions_received_metric).to receive(:is_applicable?) { true }
+      expect(transactions_received_metric).to receive(:applicable?) { true }
 
       transactions_with_outcome_metric = instance_double(AggregatedTransactionsWithOutcomeMetric)
       expect(AggregatedTransactionsWithOutcomeMetric).to receive(:new).with(root, time_period) { transactions_with_outcome_metric }
-      expect(transactions_with_outcome_metric).to receive(:is_applicable?) { true }
+      expect(transactions_with_outcome_metric).to receive(:applicable?) { true }
 
-      expect(metrics.metrics).to match_array([calls_received_metric, transactions_received_metric, transactions_with_outcome_metric])
+      expect(metrics.totals).to match_array([calls_received_metric, transactions_received_metric, transactions_with_outcome_metric])
     end
   end
 end

--- a/spec/models/metrics_spec.rb
+++ b/spec/models/metrics_spec.rb
@@ -16,12 +16,15 @@ RSpec.describe Metrics, type: :model do
     it 'returns aggregated metrics for the root object' do
       calls_received_metric = instance_double(AggregatedCallsReceivedMetric)
       expect(AggregatedCallsReceivedMetric).to receive(:new).with(root, time_period) { calls_received_metric }
+      expect(calls_received_metric).to receive(:is_applicable?) { true }
 
       transactions_received_metric = instance_double(AggregatedTransactionsReceivedMetric)
       expect(AggregatedTransactionsReceivedMetric).to receive(:new).with(root, time_period) { transactions_received_metric }
+      expect(transactions_received_metric).to receive(:is_applicable?) { true }
 
       transactions_with_outcome_metric = instance_double(AggregatedTransactionsWithOutcomeMetric)
       expect(AggregatedTransactionsWithOutcomeMetric).to receive(:new).with(root, time_period) { transactions_with_outcome_metric }
+      expect(transactions_with_outcome_metric).to receive(:is_applicable?) { true }
 
       expect(metrics.metrics).to match_array([calls_received_metric, transactions_received_metric, transactions_with_outcome_metric])
     end

--- a/spec/support/metrics_shared_examples.rb
+++ b/spec/support/metrics_shared_examples.rb
@@ -16,18 +16,33 @@ RSpec.shared_examples_for 'uses the correct child entites, depending on the grou
     metric_doubles = children.each.with_object([]) do |child, memo|
       double = instance_double(AggregatedCallsReceivedMetric)
       allow(AggregatedCallsReceivedMetric).to receive(:new).with(child, time_period) { double }
+      allow(double).to receive(:is_applicable?) { true }
 
       memo << double
     end
 
     metrics = government_metrics.metric_groups.flat_map(&:metrics)
     expect(metrics).to include(*metric_doubles)
+  end
+
+  it 'does not include aggregated calls received metric, for each child entry where not applicable' do
+    metric_doubles = children.each.with_object([]) do |child, memo|
+      double = instance_double(AggregatedCallsReceivedMetric)
+      allow(AggregatedCallsReceivedMetric).to receive(:new).with(child, time_period) { double }
+      allow(double).to receive(:is_applicable?) { false }
+
+      memo << double
+    end
+
+    metrics = government_metrics.metric_groups.flat_map(&:metrics)
+    expect(metrics).not_to include(*metric_doubles)
   end
 
   it 'includes aggregated transactions received metric, for each child entity' do
     metric_doubles = children.each.with_object([]) do |child, memo|
       double = instance_double(AggregatedTransactionsReceivedMetric)
       allow(AggregatedTransactionsReceivedMetric).to receive(:new).with(child, time_period) { double }
+      allow(double).to receive(:is_applicable?) { true }
 
       memo << double
     end
@@ -36,15 +51,42 @@ RSpec.shared_examples_for 'uses the correct child entites, depending on the grou
     expect(metrics).to include(*metric_doubles)
   end
 
+  it 'does not include aggregated transactions received metric, for each child entity when not applicable' do
+    metric_doubles = children.each.with_object([]) do |child, memo|
+      double = instance_double(AggregatedTransactionsReceivedMetric)
+      allow(AggregatedTransactionsReceivedMetric).to receive(:new).with(child, time_period) { double }
+      allow(double).to receive(:is_applicable?) { false }
+
+      memo << double
+    end
+
+    metrics = government_metrics.metric_groups.flat_map(&:metrics)
+    expect(metrics).not_to include(*metric_doubles)
+  end
+
   it 'includes aggregated transactions received metric, for each child entity' do
     metric_doubles = children.each.with_object([]) do |child, memo|
       double = instance_double(AggregatedTransactionsWithOutcomeMetric)
       allow(AggregatedTransactionsWithOutcomeMetric).to receive(:new).with(child, time_period) { double }
+      allow(double).to receive(:is_applicable?) { true }
 
       memo << double
     end
 
     metrics = government_metrics.metric_groups.flat_map(&:metrics)
     expect(metrics).to include(*metric_doubles)
+  end
+
+  it 'does not include aggregated transactions received metric, for each child entity when not applicable' do
+    metric_doubles = children.each.with_object([]) do |child, memo|
+      double = instance_double(AggregatedTransactionsWithOutcomeMetric)
+      allow(AggregatedTransactionsWithOutcomeMetric).to receive(:new).with(child, time_period) { double }
+      allow(double).to receive(:is_applicable?) { false }
+
+      memo << double
+    end
+
+    metrics = government_metrics.metric_groups.flat_map(&:metrics)
+    expect(metrics).not_to include(*metric_doubles)
   end
 end

--- a/spec/support/metrics_shared_examples.rb
+++ b/spec/support/metrics_shared_examples.rb
@@ -2,9 +2,11 @@ RSpec.shared_examples_for 'uses the correct child entites, depending on the grou
   subject(:government_metrics) { described_class.new(root, group_by: group_by, time_period: time_period) }
 
   before do
-    allow(AggregatedCallsReceivedMetric).to receive(:new)
-    allow(AggregatedTransactionsReceivedMetric).to receive(:new)
-    allow(AggregatedTransactionsWithOutcomeMetric).to receive(:new)
+    obj = double(applicable?: true)
+
+    allow(AggregatedCallsReceivedMetric).to receive(:new) { obj }
+    allow(AggregatedTransactionsReceivedMetric).to receive(:new) { obj }
+    allow(AggregatedTransactionsWithOutcomeMetric).to receive(:new) { obj }
   end
 
   it 'returns a metric group for each child entity' do

--- a/spec/support/metrics_shared_examples.rb
+++ b/spec/support/metrics_shared_examples.rb
@@ -16,7 +16,7 @@ RSpec.shared_examples_for 'uses the correct child entites, depending on the grou
     metric_doubles = children.each.with_object([]) do |child, memo|
       double = instance_double(AggregatedCallsReceivedMetric)
       allow(AggregatedCallsReceivedMetric).to receive(:new).with(child, time_period) { double }
-      allow(double).to receive(:is_applicable?) { true }
+      allow(double).to receive(:applicable?) { true }
 
       memo << double
     end
@@ -29,7 +29,7 @@ RSpec.shared_examples_for 'uses the correct child entites, depending on the grou
     metric_doubles = children.each.with_object([]) do |child, memo|
       double = instance_double(AggregatedCallsReceivedMetric)
       allow(AggregatedCallsReceivedMetric).to receive(:new).with(child, time_period) { double }
-      allow(double).to receive(:is_applicable?) { false }
+      allow(double).to receive(:applicable?) { false }
 
       memo << double
     end
@@ -42,7 +42,7 @@ RSpec.shared_examples_for 'uses the correct child entites, depending on the grou
     metric_doubles = children.each.with_object([]) do |child, memo|
       double = instance_double(AggregatedTransactionsReceivedMetric)
       allow(AggregatedTransactionsReceivedMetric).to receive(:new).with(child, time_period) { double }
-      allow(double).to receive(:is_applicable?) { true }
+      allow(double).to receive(:applicable?) { true }
 
       memo << double
     end
@@ -55,7 +55,7 @@ RSpec.shared_examples_for 'uses the correct child entites, depending on the grou
     metric_doubles = children.each.with_object([]) do |child, memo|
       double = instance_double(AggregatedTransactionsReceivedMetric)
       allow(AggregatedTransactionsReceivedMetric).to receive(:new).with(child, time_period) { double }
-      allow(double).to receive(:is_applicable?) { false }
+      allow(double).to receive(:applicable?) { false }
 
       memo << double
     end
@@ -68,7 +68,7 @@ RSpec.shared_examples_for 'uses the correct child entites, depending on the grou
     metric_doubles = children.each.with_object([]) do |child, memo|
       double = instance_double(AggregatedTransactionsWithOutcomeMetric)
       allow(AggregatedTransactionsWithOutcomeMetric).to receive(:new).with(child, time_period) { double }
-      allow(double).to receive(:is_applicable?) { true }
+      allow(double).to receive(:applicable?) { true }
 
       memo << double
     end
@@ -81,7 +81,7 @@ RSpec.shared_examples_for 'uses the correct child entites, depending on the grou
     metric_doubles = children.each.with_object([]) do |child, memo|
       double = instance_double(AggregatedTransactionsWithOutcomeMetric)
       allow(AggregatedTransactionsWithOutcomeMetric).to receive(:new).with(child, time_period) { double }
-      allow(double).to receive(:is_applicable?) { false }
+      allow(double).to receive(:applicable?) { false }
 
       memo << double
     end


### PR DESCRIPTION
When a metric has no items then this PR will exclude it from the
response. This is used to denote that metric as being not-applicable.

This breaks view-data, until it is changed to handle the missing metrics in the API response. Don't merge until https://github.com/alphagov/gsd-view-data/pull/48 is also merged