### PR TITLE
Serialize Aggregated Metrics according to Not Applicable / Not Provided semantics.

### DIFF
--- a/app/models/aggregated_calls_received_metric.rb
+++ b/app/models/aggregated_calls_received_metric.rb
@@ -2,19 +2,34 @@ class AggregatedCallsReceivedMetric
   alias :read_attribute_for_serialization :send
 
   def initialize(organisation, time_period)
-    @sampled = false
-    @totals = CallsReceivedMetric
-      .where(service_code: organisation.services.pluck(:natural_key))
-      .where('starts_on >= ? AND ends_on <= ?', time_period.starts_on, time_period.ends_on)
-      .each.with_object({}) do |metric, memo|
-        if !metric.quantity.nil?
-          memo[metric.item] ||= 0
-          memo[metric.item] += metric.quantity
+    @organisation = organisation
+    @time_period = time_period
+
+    @sampled = metrics.any?(&:sampled)
+
+    defaults = Hash.new(Metric::NOT_APPLICABLE)
+    defaults['sampled-total'] = 0
+    @totals = metrics.group_by(&:item).each.with_object(defaults) do |(item, metrics), memo|
+      quantity = begin
+        if metrics.any?(&:quantity)
+          metrics.sum { |metric| metric.quantity || 0 }
+        else
+          Metric::NOT_PROVIDED
         end
-        memo['sampled-total'] ||= 0
-        memo['sampled-total'] += metric.sample_size || (metric.quantity || 0)
-        @sampled |= metric.sampled
       end
+
+      memo[item] = quantity
+
+      if item == 'total'
+        memo['sampled-total'] = begin
+          if metrics.any? { |metric| metric.sample_size || metric.quantity }
+            metrics.sum { |metric| metric.sample_size || metric.quantity || 0 }
+          else
+            Metric::NOT_PROVIDED
+          end
+        end
+      end
+    end
   end
 
   def total
@@ -42,4 +57,14 @@ class AggregatedCallsReceivedMetric
   end
 
   attr_reader :sampled
+
+private
+
+  attr_reader :organisation, :time_period
+
+  def metrics
+    @metrics ||= CallsReceivedMetric
+      .where(service_code: organisation.services.pluck(:natural_key))
+      .where('starts_on >= ? AND ends_on <= ?', time_period.starts_on, time_period.ends_on)
+  end
 end

--- a/app/models/aggregated_transactions_with_outcome_metric.rb
+++ b/app/models/aggregated_transactions_with_outcome_metric.rb
@@ -5,29 +5,26 @@ class AggregatedTransactionsWithOutcomeMetric
     @organisation = organisation
     @time_period = time_period
 
-    defaults = { total: Metric::NOT_APPLICABLE, with_intended_outcome: Metric::NOT_APPLICABLE }
+    defaults = Hash.new(Metric::NOT_APPLICABLE)
     @totals = metrics.group_by(&:outcome).each.with_object(defaults) do |(outcome, metrics), memo|
-      quantity = if metrics.any?(&:quantity)
-                   metrics.sum { |metric| metric.quantity || 0 }
-                 else
-                   Metric::NOT_PROVIDED
-                 end
-
-      case outcome
-      when 'any'
-        memo[:total] = quantity
-      when 'intended'
-        memo[:with_intended_outcome] = quantity
+      quantity = begin
+        if metrics.any?(&:quantity)
+          metrics.sum { |metric| metric.quantity || 0 }
+        else
+          Metric::NOT_PROVIDED
+        end
       end
+
+      memo[outcome] = quantity
     end
   end
 
   def total
-    @totals[:total]
+    @totals['any']
   end
 
   def with_intended_outcome
-    @totals[:with_intended_outcome]
+    @totals['intended']
   end
 
 private

--- a/app/models/aggregated_transactions_with_outcome_metric.rb
+++ b/app/models/aggregated_transactions_with_outcome_metric.rb
@@ -2,13 +2,24 @@ class AggregatedTransactionsWithOutcomeMetric
   alias :read_attribute_for_serialization :send
 
   def initialize(organisation, time_period)
-    @totals = TransactionsWithOutcomeMetric
-      .where(service_code: organisation.services.pluck(:natural_key))
-      .where('starts_on >= ? AND ends_on <= ?', time_period.starts_on, time_period.ends_on)
-      .each.with_object(total: 0, with_intended_outcome: 0) do |metric, memo|
-        memo[:total] += metric.quantity || 0 if metric.outcome == 'any'
-        memo[:with_intended_outcome] += metric.quantity || 0 if metric.outcome == 'intended'
+    @organisation = organisation
+    @time_period = time_period
+
+    defaults = { total: Metric::NOT_APPLICABLE, with_intended_outcome: Metric::NOT_APPLICABLE }
+    @totals = metrics.group_by(&:outcome).each.with_object(defaults) do |(outcome, metrics), memo|
+      quantity = if metrics.any?(&:quantity)
+                   metrics.sum { |metric| metric.quantity || 0 }
+                 else
+                   Metric::NOT_PROVIDED
+                 end
+
+      case outcome
+      when 'any'
+        memo[:total] = quantity
+      when 'intended'
+        memo[:with_intended_outcome] = quantity
       end
+    end
   end
 
   def total
@@ -17,5 +28,15 @@ class AggregatedTransactionsWithOutcomeMetric
 
   def with_intended_outcome
     @totals[:with_intended_outcome]
+  end
+
+private
+
+  attr_reader :organisation, :time_period
+
+  def metrics
+    TransactionsWithOutcomeMetric
+      .where(service_code: organisation.services.pluck(:natural_key))
+      .where('starts_on >= ? AND ends_on <= ?', time_period.starts_on, time_period.ends_on)
   end
 end

--- a/app/models/concerns/metric.rb
+++ b/app/models/concerns/metric.rb
@@ -1,0 +1,4 @@
+module Metric
+  NOT_APPLICABLE = :not_applicable
+  NOT_PROVIDED = :not_provided
+end

--- a/app/serializers/aggregated_calls_received_metric_serializer.rb
+++ b/app/serializers/aggregated_calls_received_metric_serializer.rb
@@ -1,6 +1,10 @@
 class AggregatedCallsReceivedMetricSerializer < ActiveModel::Serializer
-  attributes :type, :total, :get_information, :chase_progress,
-             :challenge_a_decision, :other, :sampled, :sampled_total
+  extend MetricSerializer
+
+  attributes :type
+
+  metrics :total, :get_information, :chase_progress,
+          :challenge_a_decision, :other, :sampled, :sampled_total
 
   def type
     'calls-received'

--- a/app/serializers/aggregated_transactions_received_metric_serializer.rb
+++ b/app/serializers/aggregated_transactions_received_metric_serializer.rb
@@ -1,5 +1,8 @@
 class AggregatedTransactionsReceivedMetricSerializer < ActiveModel::Serializer
-  attributes :type, :total, :online, :phone, :paper, :face_to_face, :other
+  extend MetricSerializer
+
+  attributes :type
+  metrics :total, :online, :phone, :paper, :face_to_face, :other
 
   def type
     'transactions-received'

--- a/app/serializers/aggregated_transactions_with_outcome_metric_serializer.rb
+++ b/app/serializers/aggregated_transactions_with_outcome_metric_serializer.rb
@@ -1,5 +1,8 @@
 class AggregatedTransactionsWithOutcomeMetricSerializer < ActiveModel::Serializer
-  attributes :type, :total, :with_intended_outcome
+  extend MetricSerializer
+
+  attributes :type
+  metrics :total, :with_intended_outcome
 
   def type
     'transactions-with-outcome'

--- a/app/serializers/concerns/metric_serializer.rb
+++ b/app/serializers/concerns/metric_serializer.rb
@@ -1,0 +1,19 @@
+module MetricSerializer
+  def metric(name)
+    value = ->(serializer) { serializer.object.read_attribute_for_serialization(name) }
+    applicable = ->(serializer) { value.(serializer) != Metric::NOT_APPLICABLE }
+
+    attribute name, if: applicable do
+      result = value.(self)
+      if result == Metric::NOT_PROVIDED
+        nil
+      else
+        result
+      end
+    end
+  end
+
+  def metrics(*names)
+    names.each { |name| metric(name) }
+  end
+end

--- a/spec/models/aggregated_calls_received_metric_spec.rb
+++ b/spec/models/aggregated_calls_received_metric_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       metric = AggregatedCallsReceivedMetric.new(department, time_period)
       expect(metric.total).to eq(360)
       expect(metric.get_information).to eq(330)
-      expect(metric.chase_progress).to be_nil
-      expect(metric.challenge_a_decision).to be_nil
-      expect(metric.other).to be_nil
+      expect(metric.chase_progress).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.challenge_a_decision).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.other).to eq(Metric::NOT_APPLICABLE)
     end
 
     specify 'for a given delivery_organisation' do
@@ -77,9 +77,9 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       metric = AggregatedCallsReceivedMetric.new(delivery_organisation, time_period)
       expect(metric.total).to eq(360)
       expect(metric.get_information).to eq(330)
-      expect(metric.chase_progress).to be_nil
-      expect(metric.challenge_a_decision).to be_nil
-      expect(metric.other).to be_nil
+      expect(metric.chase_progress).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.challenge_a_decision).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.other).to eq(Metric::NOT_APPLICABLE)
     end
 
     specify 'for a given service' do
@@ -106,9 +106,9 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       metric = AggregatedCallsReceivedMetric.new(service, time_period)
       expect(metric.total).to eq(180)
       expect(metric.get_information).to eq(165)
-      expect(metric.chase_progress).to be_nil
-      expect(metric.challenge_a_decision).to be_nil
-      expect(metric.other).to be_nil
+      expect(metric.chase_progress).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.challenge_a_decision).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.other).to eq(Metric::NOT_APPLICABLE)
     end
 
     context 'aggregating sampled & non-sampled data' do
@@ -137,6 +137,37 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
         expect(metric.sampled).to be_falsey
         expect(metric.sampled_total).to eq(180)
       end
+    end
+
+    specify 'with not applicable fields' do
+      service = FactoryGirl.create(:service)
+
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      metric = AggregatedCallsReceivedMetric.new(service, time_period)
+
+      expect(metric.total).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.get_information).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.chase_progress).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.challenge_a_decision).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.other).to eq(Metric::NOT_APPLICABLE)
+    end
+
+    specify 'with not provided fields' do
+      service = FactoryGirl.create(:service)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: nil)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: nil)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'chase-progress', quantity: nil)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'challenge-a-decision', quantity: nil)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'other', quantity: nil)
+
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-01-31'))
+      metric = AggregatedCallsReceivedMetric.new(service, time_period)
+
+      expect(metric.total).to eq(Metric::NOT_PROVIDED)
+      expect(metric.get_information).to eq(Metric::NOT_PROVIDED)
+      expect(metric.chase_progress).to eq(Metric::NOT_PROVIDED)
+      expect(metric.challenge_a_decision).to eq(Metric::NOT_PROVIDED)
+      expect(metric.other).to eq(Metric::NOT_PROVIDED)
     end
   end
 end

--- a/spec/models/aggregated_transactions_received_metric_spec.rb
+++ b/spec/models/aggregated_transactions_received_metric_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       expect(metric.total).to eq(2200)
       expect(metric.online).to eq(1200)
       expect(metric.phone).to eq(1000)
-      expect(metric.paper).to be_nil
-      expect(metric.face_to_face).to be_nil
-      expect(metric.other).to be_nil
+      expect(metric.paper).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.face_to_face).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.other).to eq(Metric::NOT_APPLICABLE)
     end
 
     specify 'for a given delivery organisation' do
@@ -65,9 +65,9 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       expect(metric.total).to eq(2200)
       expect(metric.online).to eq(1200)
       expect(metric.phone).to eq(1000)
-      expect(metric.paper).to be_nil
-      expect(metric.face_to_face).to be_nil
-      expect(metric.other).to be_nil
+      expect(metric.paper).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.face_to_face).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.other).to eq(Metric::NOT_APPLICABLE)
     end
 
     specify 'for a given service' do
@@ -90,9 +90,41 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       expect(metric.total).to eq(1100)
       expect(metric.online).to eq(600)
       expect(metric.phone).to eq(500)
-      expect(metric.paper).to be_nil
-      expect(metric.face_to_face).to be_nil
-      expect(metric.other).to be_nil
+      expect(metric.paper).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.face_to_face).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.other).to eq(Metric::NOT_APPLICABLE)
+    end
+
+    specify 'with not applicable fields' do
+      service = FactoryGirl.create(:service)
+
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      metric = AggregatedTransactionsReceivedMetric.new(service, time_period)
+
+      expect(metric.total).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.online).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.phone).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.paper).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.face_to_face).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.other).to eq(Metric::NOT_APPLICABLE)
+    end
+
+    specify 'with not provided fields' do
+      service = FactoryGirl.create(:service)
+      FactoryGirl.create(:transactions_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', channel: 'online', quantity: nil)
+      FactoryGirl.create(:transactions_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', channel: 'phone', quantity: nil)
+      FactoryGirl.create(:transactions_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', channel: 'paper', quantity: nil)
+      FactoryGirl.create(:transactions_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', channel: 'face_to_face', quantity: nil)
+      FactoryGirl.create(:transactions_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', channel: 'other', quantity: nil)
+
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-01-31'))
+      metric = AggregatedTransactionsReceivedMetric.new(service, time_period)
+
+      expect(metric.online).to eq(Metric::NOT_PROVIDED)
+      expect(metric.phone).to eq(Metric::NOT_PROVIDED)
+      expect(metric.paper).to eq(Metric::NOT_PROVIDED)
+      expect(metric.face_to_face).to eq(Metric::NOT_PROVIDED)
+      expect(metric.other).to eq(Metric::NOT_PROVIDED)
     end
   end
 end

--- a/spec/models/aggregated_transactions_with_outcome_metric_spec.rb
+++ b/spec/models/aggregated_transactions_with_outcome_metric_spec.rb
@@ -92,5 +92,27 @@ RSpec.describe AggregatedTransactionsWithOutcomeMetric, type: :model do
       expect(metric.total).to eq(180)
       expect(metric.with_intended_outcome).to eq(165)
     end
+
+    specify 'with not applicable fields' do
+      service = FactoryGirl.create(:service)
+
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      metric = AggregatedTransactionsWithOutcomeMetric.new(service, time_period)
+
+      expect(metric.total).to eq(Metric::NOT_APPLICABLE)
+      expect(metric.with_intended_outcome).to eq(Metric::NOT_APPLICABLE)
+    end
+
+    specify 'with not provided fields' do
+      service = FactoryGirl.create(:service)
+      FactoryGirl.create(:transactions_with_outcome_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', outcome: 'any', quantity: nil)
+      FactoryGirl.create(:transactions_with_outcome_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', outcome: 'intended', quantity: nil)
+
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-01-31'))
+      metric = AggregatedTransactionsWithOutcomeMetric.new(service, time_period)
+
+      expect(metric.total).to eq(Metric::NOT_PROVIDED)
+      expect(metric.with_intended_outcome).to eq(Metric::NOT_PROVIDED)
+    end
   end
 end

--- a/spec/serializers/aggregated_calls_received_metric_serializer_spec.rb
+++ b/spec/serializers/aggregated_calls_received_metric_serializer_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe AggregatedCallsReceivedMetricSerializer, type: :serializer do
+  let(:metric) { serializable_double(AggregatedCallsReceivedMetric, total: 1000, get_information: 456, chase_progress: 789, challenge_a_decision: 876, other: 543, sampled: false, sampled_total: 200) }
+  subject(:serializer) { AggregatedCallsReceivedMetricSerializer.new(metric) }
+
+  it 'serializes a aggregated calls received metric' do
+    expect {
+      serializer.to_json
+    }.to_not raise_error
+  end
+
+  describe '#total', attribute: :total do
+    it_behaves_like 'serialized metric attribute'
+  end
+
+  describe '#get_information', attribute: :get_information do
+    it_behaves_like 'serialized metric attribute'
+  end
+
+  describe '#chase_progress', attribute: :chase_progress do
+    it_behaves_like 'serialized metric attribute'
+  end
+
+  describe '#challenge_a_decision', attribute: :challenge_a_decision do
+    it_behaves_like 'serialized metric attribute'
+  end
+
+  describe '#other', attribute: :other do
+    it_behaves_like 'serialized metric attribute'
+  end
+end

--- a/spec/serializers/aggregated_transactions_received_serializer_spec.rb
+++ b/spec/serializers/aggregated_transactions_received_serializer_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe AggregatedTransactionsReceivedMetricSerializer, type: :serializer do
+  let(:metric) { serializable_double(AggregatedTransactionsReceivedMetric, total: 1000, online: 456, phone: 789, paper: 876, face_to_face: 843, other: 543) }
+  subject(:serializer) { AggregatedTransactionsReceivedMetricSerializer.new(metric) }
+
+  it 'serializes a aggregated transactions received metric' do
+    expect {
+      serializer.to_json
+    }.to_not raise_error
+  end
+
+  describe '#total', attribute: :total do
+    it_behaves_like 'serialized metric attribute'
+  end
+
+  describe '#online', attribute: :online do
+    it_behaves_like 'serialized metric attribute'
+  end
+
+  describe '#phone', attribute: :phone do
+    it_behaves_like 'serialized metric attribute'
+  end
+
+  describe '#paper', attribute: :paper do
+    it_behaves_like 'serialized metric attribute'
+  end
+
+  describe '#face_to_face', attribute: :face_to_face do
+    it_behaves_like 'serialized metric attribute'
+  end
+
+  describe '#other', attribute: :other do
+    it_behaves_like 'serialized metric attribute'
+  end
+end

--- a/spec/serializers/aggregated_transactions_with_outcome_metric_serializer_spec.rb
+++ b/spec/serializers/aggregated_transactions_with_outcome_metric_serializer_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe AggregatedTransactionsWithOutcomeMetricSerializer, type: :serializer do
+  let(:metric) {
+    double = instance_double(AggregatedTransactionsWithOutcomeMetric, total: 123, with_intended_outcome: 456)
+    allow(double).to receive(:read_attribute_for_serialization) do |*args|
+      double.send(*args)
+    end
+    double
+  }
+  subject(:serializer) { AggregatedTransactionsWithOutcomeMetricSerializer.new(metric) }
+
+  it 'serializes a aggregated transactions with outcome metric' do
+    expect {
+      serializer.to_json
+    }.to_not raise_error
+  end
+
+  describe '#total' do
+    it "attribute isn't present if not applicable" do
+      allow(metric).to receive(:total) { Metric::NOT_APPLICABLE }
+
+      expect(serializer.attributes[:total]).to be_nil
+    end
+
+    it "attribute is present, but nil if not provided" do
+      allow(metric).to receive(:total) { Metric::NOT_PROVIDED }
+
+      expect(serializer.attributes[:total]).to be_nil
+    end
+
+    it "attribute is present, and populated if provided" do
+      allow(metric).to receive(:total) { 1_000_000 }
+
+      expect(serializer.attributes[:total]).to eq(1_000_000)
+    end
+  end
+
+  describe '#with_intended_outcome' do
+    it "attribute isn't present if not applicable" do
+      allow(metric).to receive(:with_intended_outcome) { Metric::NOT_APPLICABLE }
+
+      expect(serializer.attributes[:with_intended_outcome]).to be_nil
+    end
+
+    it "attribute is present, but nil if not provided" do
+      allow(metric).to receive(:with_intended_outcome) { Metric::NOT_PROVIDED }
+
+      expect(serializer.attributes[:with_intended_outcome]).to be_nil
+    end
+
+    it "attribute is present, and populated if provided" do
+      allow(metric).to receive(:with_intended_outcome) { 1_000_000 }
+
+      expect(serializer.attributes[:with_intended_outcome]).to eq(1_000_000)
+    end
+  end
+end

--- a/spec/serializers/aggregated_transactions_with_outcome_metric_serializer_spec.rb
+++ b/spec/serializers/aggregated_transactions_with_outcome_metric_serializer_spec.rb
@@ -1,13 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AggregatedTransactionsWithOutcomeMetricSerializer, type: :serializer do
-  let(:metric) {
-    double = instance_double(AggregatedTransactionsWithOutcomeMetric, total: 123, with_intended_outcome: 456)
-    allow(double).to receive(:read_attribute_for_serialization) do |*args|
-      double.send(*args)
-    end
-    double
-  }
+  let(:metric) { serializable_double(AggregatedTransactionsWithOutcomeMetric, total: 123, with_intended_outcome: 456) }
   subject(:serializer) { AggregatedTransactionsWithOutcomeMetricSerializer.new(metric) }
 
   it 'serializes a aggregated transactions with outcome metric' do
@@ -16,43 +10,11 @@ RSpec.describe AggregatedTransactionsWithOutcomeMetricSerializer, type: :seriali
     }.to_not raise_error
   end
 
-  describe '#total' do
-    it "attribute isn't present if not applicable" do
-      allow(metric).to receive(:total) { Metric::NOT_APPLICABLE }
-
-      expect(serializer.attributes[:total]).to be_nil
-    end
-
-    it "attribute is present, but nil if not provided" do
-      allow(metric).to receive(:total) { Metric::NOT_PROVIDED }
-
-      expect(serializer.attributes[:total]).to be_nil
-    end
-
-    it "attribute is present, and populated if provided" do
-      allow(metric).to receive(:total) { 1_000_000 }
-
-      expect(serializer.attributes[:total]).to eq(1_000_000)
-    end
+  describe '#total', attribute: :total do
+    it_behaves_like 'serialized metric attribute'
   end
 
-  describe '#with_intended_outcome' do
-    it "attribute isn't present if not applicable" do
-      allow(metric).to receive(:with_intended_outcome) { Metric::NOT_APPLICABLE }
-
-      expect(serializer.attributes[:with_intended_outcome]).to be_nil
-    end
-
-    it "attribute is present, but nil if not provided" do
-      allow(metric).to receive(:with_intended_outcome) { Metric::NOT_PROVIDED }
-
-      expect(serializer.attributes[:with_intended_outcome]).to be_nil
-    end
-
-    it "attribute is present, and populated if provided" do
-      allow(metric).to receive(:with_intended_outcome) { 1_000_000 }
-
-      expect(serializer.attributes[:with_intended_outcome]).to eq(1_000_000)
-    end
+  describe '#with_intended_outcome', attribute: :with_intended_outcome do
+    it_behaves_like 'serialized metric attribute'
   end
 end

--- a/spec/support/metric_serializer_shared_examples.rb
+++ b/spec/support/metric_serializer_shared_examples.rb
@@ -1,0 +1,21 @@
+RSpec.shared_examples_for 'serialized metric attribute' do
+  let(:attribute) { |example| example.metadata[:attribute] }
+
+  it "attribute isn't present if not applicable" do
+    allow(metric).to receive(attribute) { Metric::NOT_APPLICABLE }
+
+    expect(serializer.attributes[attribute]).to be_nil
+  end
+
+  it "attribute is present, but nil if not provided" do
+    allow(metric).to receive(attribute) { Metric::NOT_PROVIDED }
+
+    expect(serializer.attributes[attribute]).to be_nil
+  end
+
+  it "attribute is present, and populated if provided" do
+    allow(metric).to receive(attribute) { 1_000_000 }
+
+    expect(serializer.attributes[attribute]).to eq(1_000_000)
+  end
+end

--- a/spec/support/serializer_double.rb
+++ b/spec/support/serializer_double.rb
@@ -1,0 +1,11 @@
+module SerializableDouble
+  def serializable_double(doubled_class, *args)
+    instance_double(doubled_class, *args).tap do |double|
+      allow(double).to receive(:read_attribute_for_serialization, &double.method(:send))
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include(SerializableDouble, type: :serializer)
+end


### PR DESCRIPTION
Change the aggregated metrics to account for not applicable and not provided metric items.

When aggregating metrics we need to retain the semantics as to whether the metric values were not applicable or not provided. If there are no metrics (rows) for that period, then we treat it as not applicable. If there are metrics but the values are NULL, then we treat it as not provided.

We also need to seralize these metrics whilst maintaining these semantics. In this case if it's not applicable then it shouldn't be serialised, if it's not provided then the attribute should be serialized with a NULL value.

This pull request also introduces a `serializable_double` and the "serialized metric
attribute" shared example so they can be shared between the aggregated metrics serializer specs.