### PR TITLE
Include completeness stats in response

### DIFF
--- a/app/models/aggregated_calls_received_metric.rb
+++ b/app/models/aggregated_calls_received_metric.rb
@@ -4,8 +4,10 @@ class AggregatedCallsReceivedMetric
   def initialize(organisation, time_period)
     @organisation = organisation
     @time_period = time_period
-
+    @completeness = {}
     @sampled = metrics.any?(&:sampled)
+
+    expected_multiplier = Completeness.multiplier(@organisation)
 
     defaults = Hash.new(Metric::NOT_APPLICABLE)
     defaults['sampled-total'] = 0
@@ -18,6 +20,10 @@ class AggregatedCallsReceivedMetric
         end
       end
 
+      @completeness[item] = {
+        actual: metrics.count { |m| !m.quantity.in?([Metric::NOT_PROVIDED, nil]) },
+        expected: @time_period.months * expected_multiplier
+      }
       memo[item] = quantity
 
       if item == 'total'
@@ -60,7 +66,7 @@ class AggregatedCallsReceivedMetric
     @channels['sampled-total']
   end
 
-  attr_reader :sampled
+  attr_reader :sampled, :completeness
 
 private
 

--- a/app/models/completeness.rb
+++ b/app/models/completeness.rb
@@ -1,0 +1,6 @@
+class Completeness
+  def self.multiplier(obj)
+    return 1 if obj === Service
+    obj.services.count
+  end
+end

--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -14,5 +14,9 @@ class TimePeriod
     @ends_on = ends_on
   end
 
+  def months
+    (@ends_on.year * 12 + @ends_on.month) - (@starts_on.year * 12 + @starts_on.month) + 1
+  end
+
   attr_reader :starts_on, :ends_on
 end

--- a/app/serializers/aggregated_calls_received_metric_serializer.rb
+++ b/app/serializers/aggregated_calls_received_metric_serializer.rb
@@ -1,7 +1,7 @@
 class AggregatedCallsReceivedMetricSerializer < ActiveModel::Serializer
   extend MetricSerializer
 
-  attributes :type
+  attributes :type, :completeness
 
   metrics :total, :get_information, :chase_progress,
           :challenge_a_decision, :other, :sampled, :sampled_total

--- a/app/serializers/aggregated_transactions_received_metric_serializer.rb
+++ b/app/serializers/aggregated_transactions_received_metric_serializer.rb
@@ -1,7 +1,7 @@
 class AggregatedTransactionsReceivedMetricSerializer < ActiveModel::Serializer
   extend MetricSerializer
 
-  attributes :type
+  attributes :type, :completeness
   metrics :total, :online, :phone, :paper, :face_to_face, :other
 
   def type

--- a/app/serializers/aggregated_transactions_with_outcome_metric_serializer.rb
+++ b/app/serializers/aggregated_transactions_with_outcome_metric_serializer.rb
@@ -1,7 +1,7 @@
 class AggregatedTransactionsWithOutcomeMetricSerializer < ActiveModel::Serializer
   extend MetricSerializer
 
-  attributes :type
+  attributes :type, :completeness
   metrics :total, :with_intended_outcome
 
   def type

--- a/spec/models/aggregated_calls_received_metric_spec.rb
+++ b/spec/models/aggregated_calls_received_metric_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 10)
       FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: 5)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
       metric = AggregatedCallsReceivedMetric.new(department, time_period)
       expect(metric.total).to eq(360)
       expect(metric.get_information).to eq(330)
@@ -73,7 +73,7 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 10)
       FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: 5)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
       metric = AggregatedCallsReceivedMetric.new(delivery_organisation, time_period)
       expect(metric.total).to eq(360)
       expect(metric.get_information).to eq(330)
@@ -102,7 +102,7 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'total', quantity: 10)
       FactoryGirl.create(:calls_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: 5)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
       metric = AggregatedCallsReceivedMetric.new(service, time_period)
       expect(metric.total).to eq(180)
       expect(metric.get_information).to eq(165)
@@ -118,7 +118,7 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
         FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'total', quantity: 60, sampled: true, sample_size: 15)
         FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'total', quantity: 70, sampled: false)
 
-        time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+        time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
         metric = AggregatedCallsReceivedMetric.new(service, time_period)
         expect(metric.total).to eq(180)
         expect(metric.sampled).to be_truthy
@@ -131,7 +131,7 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
         FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-02-01', ends_on: '2017-02-28', item: 'total', quantity: 60, sampled: false)
         FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-03-01', ends_on: '2017-03-31', item: 'total', quantity: 70, sampled: false)
 
-        time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+        time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
         metric = AggregatedCallsReceivedMetric.new(service, time_period)
         expect(metric.total).to eq(180)
         expect(metric.sampled).to be_falsey
@@ -142,7 +142,7 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
     specify 'with not applicable fields' do
       service = FactoryGirl.create(:service)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
       metric = AggregatedCallsReceivedMetric.new(service, time_period)
 
       expect(metric.total).to eq(Metric::NOT_APPLICABLE)
@@ -160,7 +160,7 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'challenge-a-decision', quantity: nil)
       FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'other', quantity: nil)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-01-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-01-31'), months: 12)
       metric = AggregatedCallsReceivedMetric.new(service, time_period)
 
       expect(metric.total).to eq(Metric::NOT_PROVIDED)

--- a/spec/models/aggregated_transactions_received_metric_spec.rb
+++ b/spec/models/aggregated_transactions_received_metric_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       other_service = FactoryGirl.create(:service, department: other_department)
       FactoryGirl.create(:transactions_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', channel: 'online', quantity: 95)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
       metric = AggregatedTransactionsReceivedMetric.new(department, time_period)
       expect(metric.total).to eq(2200)
       expect(metric.online).to eq(1200)
@@ -60,7 +60,7 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       other_service = FactoryGirl.create(:service, delivery_organisation: other_delivery_organisation)
       FactoryGirl.create(:transactions_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', channel: 'online', quantity: 95)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
       metric = AggregatedTransactionsReceivedMetric.new(delivery_organisation, time_period)
       expect(metric.total).to eq(2200)
       expect(metric.online).to eq(1200)
@@ -85,7 +85,7 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       other_service = FactoryGirl.create(:service)
       FactoryGirl.create(:transactions_received_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', channel: 'online', quantity: 95)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
       metric = AggregatedTransactionsReceivedMetric.new(service, time_period)
       expect(metric.total).to eq(1100)
       expect(metric.online).to eq(600)
@@ -98,7 +98,7 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
     specify 'with not applicable fields' do
       service = FactoryGirl.create(:service)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
       metric = AggregatedTransactionsReceivedMetric.new(service, time_period)
 
       expect(metric.total).to eq(Metric::NOT_APPLICABLE)
@@ -117,7 +117,7 @@ RSpec.describe AggregatedTransactionsReceivedMetric, type: :model do
       FactoryGirl.create(:transactions_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', channel: 'face_to_face', quantity: nil)
       FactoryGirl.create(:transactions_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', channel: 'other', quantity: nil)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-01-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-01-31'), months: 12)
       metric = AggregatedTransactionsReceivedMetric.new(service, time_period)
 
       expect(metric.online).to eq(Metric::NOT_PROVIDED)

--- a/spec/models/aggregated_transactions_with_outcome_metric_spec.rb
+++ b/spec/models/aggregated_transactions_with_outcome_metric_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe AggregatedTransactionsWithOutcomeMetric, type: :model do
       other_service = FactoryGirl.create(:service, department: other_department)
       FactoryGirl.create(:transactions_with_outcome_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', outcome: 'any', quantity: 10)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
       metric = AggregatedTransactionsWithOutcomeMetric.new(department, time_period)
       expect(metric.total).to eq(360)
       expect(metric.with_intended_outcome).to eq(330)
@@ -62,7 +62,7 @@ RSpec.describe AggregatedTransactionsWithOutcomeMetric, type: :model do
       other_service = FactoryGirl.create(:service, delivery_organisation: other_delivery_organisation)
       FactoryGirl.create(:transactions_with_outcome_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', outcome: 'any', quantity: 10)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
       metric = AggregatedTransactionsWithOutcomeMetric.new(delivery_organisation, time_period)
       expect(metric.total).to eq(360)
       expect(metric.with_intended_outcome).to eq(330)
@@ -87,7 +87,7 @@ RSpec.describe AggregatedTransactionsWithOutcomeMetric, type: :model do
       other_service = FactoryGirl.create(:service)
       FactoryGirl.create(:transactions_with_outcome_metric, service: other_service, starts_on: '2017-01-01', ends_on: '2017-01-31', outcome: 'any', quantity: 10)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-03-31'), months: 12)
       metric = AggregatedTransactionsWithOutcomeMetric.new(service, time_period)
       expect(metric.total).to eq(180)
       expect(metric.with_intended_outcome).to eq(165)
@@ -108,7 +108,7 @@ RSpec.describe AggregatedTransactionsWithOutcomeMetric, type: :model do
       FactoryGirl.create(:transactions_with_outcome_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', outcome: 'any', quantity: nil)
       FactoryGirl.create(:transactions_with_outcome_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', outcome: 'intended', quantity: nil)
 
-      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-01-31'))
+      time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-01-31'), months: 12)
       metric = AggregatedTransactionsWithOutcomeMetric.new(service, time_period)
 
       expect(metric.total).to eq(Metric::NOT_PROVIDED)

--- a/spec/serializers/aggregated_calls_received_metric_serializer_spec.rb
+++ b/spec/serializers/aggregated_calls_received_metric_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AggregatedCallsReceivedMetricSerializer, type: :serializer do
-  let(:metric) { serializable_double(AggregatedCallsReceivedMetric, total: 1000, get_information: 456, chase_progress: 789, challenge_a_decision: 876, other: 543, sampled: false, sampled_total: 200) }
+  let(:metric) { serializable_double(AggregatedCallsReceivedMetric, total: 1000, get_information: 456, chase_progress: 789, challenge_a_decision: 876, other: 543, sampled: false, sampled_total: 200, completeness: {}) }
   subject(:serializer) { AggregatedCallsReceivedMetricSerializer.new(metric) }
 
   it 'serializes a aggregated calls received metric' do

--- a/spec/serializers/aggregated_transactions_received_serializer_spec.rb
+++ b/spec/serializers/aggregated_transactions_received_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AggregatedTransactionsReceivedMetricSerializer, type: :serializer do
-  let(:metric) { serializable_double(AggregatedTransactionsReceivedMetric, total: 1000, online: 456, phone: 789, paper: 876, face_to_face: 843, other: 543) }
+  let(:metric) { serializable_double(AggregatedTransactionsReceivedMetric, total: 1000, online: 456, phone: 789, paper: 876, face_to_face: 843, other: 543, completeness: {}) }
   subject(:serializer) { AggregatedTransactionsReceivedMetricSerializer.new(metric) }
 
   it 'serializes a aggregated transactions received metric' do

--- a/spec/serializers/aggregated_transactions_with_outcome_metric_serializer_spec.rb
+++ b/spec/serializers/aggregated_transactions_with_outcome_metric_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AggregatedTransactionsWithOutcomeMetricSerializer, type: :serializer do
-  let(:metric) { serializable_double(AggregatedTransactionsWithOutcomeMetric, total: 123, with_intended_outcome: 456) }
+  let(:metric) { serializable_double(AggregatedTransactionsWithOutcomeMetric, total: 123, with_intended_outcome: 456, completeness: {}) }
   subject(:serializer) { AggregatedTransactionsWithOutcomeMetricSerializer.new(metric) }
 
   it 'serializes a aggregated transactions with outcome metric' do


### PR DESCRIPTION
For each metric we include a completeness hash showing the actual and
expected number of data points for each item.