### PR TITLE
Changes to a fixed 6 month period for testing

### DIFF
--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -1,10 +1,10 @@
 class TimePeriod
-  DEFAULT_TIME_PERIOD_DURATION = 12.months
+  DEFAULT_TIME_PERIOD_DURATION = 6.months
   DEFAULT_TIME_PERIOD_LAG = 2.months
 
   def self.default
-    ends_on = (Date.today - DEFAULT_TIME_PERIOD_LAG).end_of_month
-    starts_on = (ends_on - DEFAULT_TIME_PERIOD_DURATION + 1.day)
+    ends_on = Date.new(2017, 6, 30)  # (Date.today - DEFAULT_TIME_PERIOD_LAG).end_of_month
+    starts_on = Date.new(2017, 1, 1) # (ends_on - DEFAULT_TIME_PERIOD_DURATION + 1.day)
 
     new(starts_on, ends_on)
   end

--- a/spec/models/time_period_spec.rb
+++ b/spec/models/time_period_spec.rb
@@ -8,12 +8,16 @@ RSpec.describe TimePeriod, type: :model do
       end
     end
 
-    it 'starts on 12 months before the end date' do
-      expect(period.starts_on).to eq(Date.parse('2016-04-01'))
+    it 'starts on 6 months before the end date' do
+      expect(period.starts_on).to eq(Date.parse('2017-01-01'))
     end
 
-    it 'ends on the end of the month 2 months ago' do
-      expect(period.ends_on).to eq(Date.parse('2017-03-31'))
+    it 'ends on the end of the month' do
+      expect(period.ends_on).to eq(Date.parse('2017-06-30'))
+    end
+
+    it 'is exactly 6 months apart' do
+      expect(period.months).to eq(6)
     end
   end
 end


### PR DESCRIPTION
For the next round of testing, we want to show higher scores, so this PR fixes the date period from 1st Jan to 30th June 2017.

We should revert this after testing.