### PR TITLE
Strips whitespace when looking for existing service names

### DIFF
--- a/app/importers/metrics_importer.rb
+++ b/app/importers/metrics_importer.rb
@@ -40,7 +40,7 @@ class MetricsImporter
   end
 
   def import_row(row)
-    service = service(row.service_name)
+    service = service(row.service_name.strip)
     delivery_organisation = delivery_organisation(row.delivery_organisation_name)
 
     service.natural_key ||= SecureRandom.hex(2)


### PR DESCRIPTION
Found a service with trailing whitespace so we should strip it during creation