### PR TITLE
Adds new metric item to Calls Received.

### DIFF
--- a/app/importers/metrics_importer.rb
+++ b/app/importers/metrics_importer.rb
@@ -76,6 +76,7 @@ class MetricsImporter
 
     create_calls_received_metric = ->(item, quantity) { create_metric.(CallsReceivedMetric, quantity, item: item, sampled: false) }
     create_calls_received_metric.('total', row.calls_received)
+    create_calls_received_metric.('perform-transaction', row.calls_received_perform_transaction)
     create_calls_received_metric.('get-information', row.calls_received_get_information)
     create_calls_received_metric.('chase-progress', row.calls_received_chase_progress)
     create_calls_received_metric.('challenge-a-decision', row.calls_received_challenge_a_decision)
@@ -207,6 +208,10 @@ private
 
     def calls_received
       parse_metric(@row[13])
+    end
+
+    def calls_received_perform_transaction
+      transactions_received_phone
     end
 
     def calls_received_get_information

--- a/app/models/aggregated_calls_received_metric.rb
+++ b/app/models/aggregated_calls_received_metric.rb
@@ -58,6 +58,10 @@ class AggregatedCallsReceivedMetric
     @channels['challenge-a-decision']
   end
 
+  def perform_transaction
+    @channels['perform-transaction']
+  end
+
   def other
     @channels['other']
   end

--- a/app/serializers/aggregated_calls_received_metric_serializer.rb
+++ b/app/serializers/aggregated_calls_received_metric_serializer.rb
@@ -3,7 +3,7 @@ class AggregatedCallsReceivedMetricSerializer < ActiveModel::Serializer
 
   attributes :type, :completeness
 
-  metrics :total, :get_information, :chase_progress,
+  metrics :total, :get_information, :chase_progress, :perform_transaction,
           :challenge_a_decision, :other, :sampled, :sampled_total
 
   def type

--- a/db/migrate/20170920140707_update_trxn_call_received.rb
+++ b/db/migrate/20170920140707_update_trxn_call_received.rb
@@ -1,0 +1,26 @@
+class UpdateTrxnCallReceived < ActiveRecord::Migration[5.0]
+  def change
+    CallsReceivedMetric.where(item: 'total').each do |cr|
+      current = CallsReceivedMetric.where(
+        item: 'perform-transaction',
+        starts_on: cr.starts_on,
+        ends_on: cr.ends_on
+      ).first
+      next if current
+
+      phone_trxn = TransactionsReceivedMetric.where(
+        channel: 'phone',
+        service_code: cr.service_code,
+        starts_on: cr.starts_on,
+        ends_on: cr.ends_on
+      ).first
+      next if !phone_trxn
+
+      new_cr = cr.dup
+      new_cr.item = 'perform-transaction'
+      new_cr.quantity = phone_trxn.quantity
+      new_cr.save!
+
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170824083518) do
+ActiveRecord::Schema.define(version: 20170920140707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/aggregated_calls_received_metric_spec.rb
+++ b/spec/models/aggregated_calls_received_metric_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'get-information', quantity: nil)
       FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'chase-progress', quantity: nil)
       FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'challenge-a-decision', quantity: nil)
+      FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'perform-transaction', quantity: nil)
       FactoryGirl.create(:calls_received_metric, service: service, starts_on: '2017-01-01', ends_on: '2017-01-31', item: 'other', quantity: nil)
 
       time_period = instance_double(TimePeriod, starts_on: Date.parse('2017-01-01'), ends_on: Date.parse('2017-01-31'), months: 12)
@@ -167,6 +168,7 @@ RSpec.describe AggregatedCallsReceivedMetric, type: :model do
       expect(metric.get_information).to eq(Metric::NOT_PROVIDED)
       expect(metric.chase_progress).to eq(Metric::NOT_PROVIDED)
       expect(metric.challenge_a_decision).to eq(Metric::NOT_PROVIDED)
+      expect(metric.perform_transaction).to eq(Metric::NOT_PROVIDED)
       expect(metric.other).to eq(Metric::NOT_PROVIDED)
     end
   end

--- a/spec/serializers/aggregated_calls_received_metric_serializer_spec.rb
+++ b/spec/serializers/aggregated_calls_received_metric_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AggregatedCallsReceivedMetricSerializer, type: :serializer do
-  let(:metric) { serializable_double(AggregatedCallsReceivedMetric, total: 1000, get_information: 456, chase_progress: 789, challenge_a_decision: 876, other: 543, sampled: false, sampled_total: 200, completeness: {}) }
+  let(:metric) { serializable_double(AggregatedCallsReceivedMetric, total: 1000, get_information: 456, chase_progress: 789, challenge_a_decision: 876, other: 543, sampled: false, sampled_total: 200, perform_transaction: 100, completeness: {}) }
   subject(:serializer) { AggregatedCallsReceivedMetricSerializer.new(metric) }
 
   it 'serializes a aggregated calls received metric' do
@@ -23,6 +23,10 @@ RSpec.describe AggregatedCallsReceivedMetricSerializer, type: :serializer do
   end
 
   describe '#challenge_a_decision', attribute: :challenge_a_decision do
+    it_behaves_like 'serialized metric attribute'
+  end
+
+  describe '#perform_transaction', attribute: :perform_transaction do
     it_behaves_like 'serialized metric attribute'
   end
 


### PR DESCRIPTION
Adds a new metric item, 'perform-transaction' to the calls received
metric to hold data about Calls made to perform a transaction.

Modifies the importer to (for now) just copy the data from
TransactionsReceived's phone item (which will be the default at some
point if the value isn't provided). Once we have changed the input form
for the data we can use that value instead.

Also includes a migration that will iterate through current data and if
there is not already a perform-transaction item for each total then it
will copy the data from the TransactionReceivedMetric#phone for the same
service and time period.