### PR TITLE
[WIP] Allow conversion from MonthlyServiceMetrics to the API models

### DIFF
--- a/app/models/monthly_service_metrics.rb
+++ b/app/models/monthly_service_metrics.rb
@@ -9,6 +9,8 @@ class MonthlyServiceMetrics < ApplicationRecord
 
   validates_uniqueness_of :month, scope: :service, strict: true
 
+  scope :unpublished, -> { where(published: false) }
+
   def publish_date
     if month
       month.date + 2.months

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -1,0 +1,110 @@
+class Publisher
+  def self.publish(monthly_metrics)
+    new.publish(monthly_metrics)
+  end
+
+  def publish(monthly_metrics)
+    service = Service.find(monthly_metrics.service_id)
+    beginning_of_month = monthly_metrics.month.date.beginning_of_month
+    end_of_month = monthly_metrics.month.date.end_of_month
+
+    publish_calls(service, monthly_metrics, beginning_of_month, end_of_month)
+    publish_transactions_received(service, monthly_metrics, beginning_of_month, end_of_month)
+    publish_transactions_with_outcome(service, monthly_metrics, beginning_of_month, end_of_month)
+
+    monthly_metrics.published = true
+    monthly_metrics.save!
+  end
+
+  def publish_transactions_received(service, monthly_metrics, beginning_of_month, end_of_month)
+    mapping = delete_not_applicable_items(service,
+      "online" => :online_transactions,
+      "phone" => :phone_transactions,
+      "paper" => :paper_transactions,
+      "face-to-face" => :face_to_face_transactions,
+      "other" => :other_transactions)
+
+    delivery_org = service.delivery_organisation.natural_key
+    department = service.delivery_organisation.department.natural_key
+
+    # Delete any existing values
+    TransactionsReceivedMetric.where(service_code: service.natural_key, starts_on: beginning_of_month).destroy_all
+
+    mapping.each do |item_name, metric|
+      TransactionsReceivedMetric.create!(
+        department_code: department,
+        delivery_organisation_code: delivery_org,
+        service_code: service.natural_key,
+        starts_on: beginning_of_month,
+        ends_on: end_of_month,
+        channel: item_name,
+        quantity: monthly_metrics.send(metric)
+      )
+    end
+  end
+
+  def publish_transactions_with_outcome(service, monthly_metrics, beginning_of_month, end_of_month)
+    mapping = delete_not_applicable_items(service,
+      "any" => :transactions_with_outcome,
+      "intended" => :transactions_with_intended_outcome)
+
+    delivery_org = service.delivery_organisation.natural_key
+    department = service.delivery_organisation.department.natural_key
+
+    # Delete any existing values
+    TransactionsWithOutcomeMetric.where(service_code: service.natural_key, starts_on: beginning_of_month).destroy_all
+
+    mapping.each do |item_name, metric|
+      TransactionsWithOutcomeMetric.create!(
+        department_code: department,
+        delivery_organisation_code: delivery_org,
+        service_code: service.natural_key,
+        starts_on: beginning_of_month,
+        ends_on: end_of_month,
+        outcome: item_name,
+        quantity: monthly_metrics.send(metric),
+      )
+    end
+  end
+
+  def publish_calls(service, monthly_metrics, beginning_of_month, end_of_month)
+    calls_mapping = delete_not_applicable_items(service,
+      "total" => :calls_received,
+      "get-information" => :calls_received_get_information,
+      "chase-progress" => :calls_received_chase_progress,
+      "challenge-a-decision" => :calls_received_challenge_decision,
+      "perform-transaction" => :calls_received_perform_transaction,
+      "other" => :calls_received_other)
+
+    delivery_org = service.delivery_organisation.natural_key
+    department = service.delivery_organisation.department.natural_key
+
+    # Delete any existing values
+    CallsReceivedMetric.where(service_code: service.natural_key, starts_on: beginning_of_month).destroy_all
+
+    calls_mapping.each do |item_name, metric|
+      CallsReceivedMetric.create!(
+        department_code: department,
+        delivery_organisation_code: delivery_org,
+        service_code: service.natural_key,
+        starts_on: beginning_of_month,
+        ends_on: end_of_month,
+        item: item_name,
+        quantity: monthly_metrics.send(metric),
+        sampled: false
+      )
+    end
+  end
+
+  def delete_not_applicable_items(service, mapping)
+    items = mapping.keys.clone
+    items.each do |item|
+      ksym = "#{mapping[item]}_applicable".to_sym
+      if !service.send(ksym)
+        mapping.delete(item)
+      end
+    end
+
+    mapping
+  end
+end

--- a/db/migrate/20171017133547_add_published_flag_to_monthly_metrics.rb
+++ b/db/migrate/20171017133547_add_published_flag_to_monthly_metrics.rb
@@ -1,0 +1,5 @@
+class AddPublishedFlagToMonthlyMetrics < ActiveRecord::Migration[5.1]
+  def change
+    add_column :monthly_service_metrics, :published, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171012104431) do
+ActiveRecord::Schema.define(version: 20171017133547) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20171012104431) do
     t.bigint "calls_received_challenge_decision"
     t.bigint "calls_received_other"
     t.bigint "calls_received_perform_transaction"
+    t.boolean "published", default: false
     t.index "service_id, date_trunc('month'::text, (month)::timestamp without time zone)", name: "unique_monthly_service_metrics", unique: true
     t.index ["service_id"], name: "index_monthly_service_metrics_on_service_id"
   end

--- a/lib/tasks/publish.rake
+++ b/lib/tasks/publish.rake
@@ -1,0 +1,11 @@
+namespace :publish do
+  desc "Publish all monthly metrics older than the start of the current month"
+  task all: :environment do
+    before = Date.today.beginning_of_month
+
+    metrics = MonthlyServiceMetrics.where("month < ? and published=false", [before])
+    metrics.each do |metric|
+      Publisher.publish(metric)
+    end
+  end
+end

--- a/lib/tasks/publish.rake
+++ b/lib/tasks/publish.rake
@@ -3,9 +3,10 @@ namespace :publish do
   task all: :environment do
     before = Date.today.beginning_of_month
 
-    metrics = MonthlyServiceMetrics.where("month < ? and published=false", [before])
-    metrics.each do |metric|
-      Publisher.publish(metric)
+    ActiveRecord::Base.transaction do
+      MonthlyServiceMetrics.unpublished.where("month < ?", [before]).find_each do |monthly_metrics|
+        Publisher.publish(monthly_metrics)
+      end
     end
   end
 end

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe Publisher, type: :model do
+  describe '#publishing actual data' do
+    it 'marks monthly service metrics as published' do
+      department = FactoryGirl.create(:department)
+      service = FactoryGirl.create(:service, department: department)
+
+      metrics = FactoryGirl.build(:monthly_service_metrics, service_id: service.id, month: YearMonth.new(2017, 11))
+      Publisher.publish(metrics)
+
+      expect(metrics.published).to eq(true)
+    end
+
+    it 'creates API models' do
+      department = FactoryGirl.create(:department)
+      service = FactoryGirl.create(:service, department: department)
+
+      metrics = FactoryGirl.build(:monthly_service_metrics,
+        service_id: service.id,
+        month: YearMonth.new(2017, 11),
+        calls_received: 100,
+        online_transactions: 200,
+        phone_transactions: 201,
+        transactions_with_outcome: 300)
+
+      Publisher.publish(metrics)
+
+      calls = CallsReceivedMetric.where(starts_on: "2017-11-01".to_date, item: "total").first
+      expect(calls).to_not be_nil
+      expect(calls.quantity).to eq(100)
+
+      online_trxn = TransactionsReceivedMetric.where(starts_on: "2017-11-01".to_date, channel: "online").first
+      expect(online_trxn).to_not be_nil
+      expect(online_trxn.quantity).to eq(200)
+
+      phone_trxn = TransactionsReceivedMetric.where(starts_on: "2017-11-01".to_date, channel: "phone").first
+      expect(phone_trxn).to_not be_nil
+      expect(phone_trxn.quantity).to eq(201)
+
+      outcomes = TransactionsWithOutcomeMetric.where(starts_on: "2017-11-01".to_date, outcome: "any").first
+      expect(outcomes).to_not be_nil
+      expect(outcomes.quantity).to eq(300)
+    end
+
+    it 'expects values to be not_provided (aka nil) if no metrics given' do
+      department = FactoryGirl.create(:department)
+      service = FactoryGirl.create(:service, department: department)
+
+      metrics = FactoryGirl.build(:monthly_service_metrics,
+        service_id: service.id,
+        month: YearMonth.new(2017, 11))
+
+      Publisher.publish(metrics)
+
+      calls = CallsReceivedMetric.where(service_code: service.natural_key, starts_on: "2017-11-01".to_date)
+      calls.each do |c|
+        expect(c.quantity).to be_nil
+      end
+      expect(calls.length).to eq(6)
+
+      trxns = TransactionsReceivedMetric.where(service_code: service.natural_key, starts_on: "2017-11-01".to_date)
+      trxns.each do |t|
+        expect(t.quantity).to be_nil
+      end
+      expect(trxns.length).to eq(5)
+    end
+
+    it 'expects values to be missing if not applicable' do
+      department = FactoryGirl.create(:department)
+      service = FactoryGirl.create(:service, department: department,
+                                   online_transactions_applicable: false,
+                                   phone_transactions_applicable: false,
+                                   paper_transactions_applicable: false,
+                                   face_to_face_transactions_applicable: false,
+                                   other_transactions_applicable: false,
+                                   transactions_with_outcome_applicable: false,
+                                   transactions_with_intended_outcome_applicable: false,
+                                   calls_received_applicable: false,
+                                   calls_received_get_information_applicable: false,
+                                   calls_received_chase_progress_applicable: false,
+                                   calls_received_challenge_decision_applicable: false,
+                                   calls_received_other_applicable: false,
+                                   calls_received_perform_transaction_applicable: false)
+
+      metrics = FactoryGirl.build(:monthly_service_metrics,
+        service_id: service.id,
+        month: YearMonth.new(2017, 11))
+
+      Publisher.publish(metrics)
+
+      calls = CallsReceivedMetric.where(service_code: service.natural_key, starts_on: "2017-11-01".to_date).count
+      expect(calls).to eq(0)
+
+      trxns = TransactionsReceivedMetric.where(service_code: service.natural_key, starts_on: "2017-11-01".to_date).count
+      expect(trxns).to eq(0)
+
+      outcomes = TransactionsWithOutcomeMetric.where(service_code: service.natural_key, starts_on: "2017-11-01".to_date).count
+      expect(outcomes).to eq(0)
+    end
+
+    it 'expects only calls if only calls are applicable' do
+      department = FactoryGirl.create(:department)
+      service = FactoryGirl.create(:service, department: department,
+                                   online_transactions_applicable: false,
+                                   phone_transactions_applicable: false,
+                                   paper_transactions_applicable: false,
+                                   face_to_face_transactions_applicable: false,
+                                   other_transactions_applicable: false,
+                                   transactions_with_outcome_applicable: false,
+                                   transactions_with_intended_outcome_applicable: false)
+
+      metrics = FactoryGirl.build(:monthly_service_metrics,
+        service_id: service.id,
+        month: YearMonth.new(2017, 11))
+
+      Publisher.publish(metrics)
+
+      calls = CallsReceivedMetric.where(service_code: service.natural_key, starts_on: "2017-11-01".to_date).count
+      expect(calls).to eq(6)
+
+      trxns = TransactionsReceivedMetric.where(service_code: service.natural_key, starts_on: "2017-11-01".to_date).count
+      expect(trxns).to eq(0)
+
+      outcomes = TransactionsWithOutcomeMetric.where(service_code: service.natural_key, starts_on: "2017-11-01".to_date).count
+      expect(outcomes).to eq(0)
+    end
+  end
+end

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Publisher, type: :model do
-  describe '#publishing actual data' do
+  describe 'publishing actual data' do
     it 'marks monthly service metrics as published' do
       department = FactoryGirl.create(:department)
       service = FactoryGirl.create(:service, department: department)


### PR DESCRIPTION
MonthlyServiceMetrics are published individually, but there is a rake
task that will publish all of the entries before the current month.

It can be run with ..

```
rake publish:all
```