### PR TITLE
Remove Authentication from Metrics Submission Form

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -8,6 +8,8 @@ module Admin
   class ApplicationController < Administrate::ApplicationController
     before_action :authenticate_admin
 
+    include AuthenticatedController
+
     def authenticate_admin
       # TODO Add authentication logic here.
     end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,3 +1,5 @@
 class APIController < ActionController::API
   include ActionController::MimeResponds
+
+  include AuthenticatedController
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  include AuthenticatedController
+
 private
 
   helper_method :page

--- a/app/controllers/concerns/authenticated_controller.rb
+++ b/app/controllers/concerns/authenticated_controller.rb
@@ -1,0 +1,29 @@
+module AuthenticatedController
+  extend ActiveSupport::Concern
+
+  include ActionController::HttpAuthentication::Basic::ControllerMethods
+
+  included do
+    before_action :_authenticate_with_http_basic
+  end
+
+  class_methods do
+    def skip_authentication
+      skip_before_action :_authenticate_with_http_basic
+    end
+  end
+
+private
+
+  def _authenticate_with_http_basic
+    return if Rails.env.development? || Rails.env.test?
+
+    authenticate_or_request_with_http_basic('Service Performance') do |name, password|
+      # This comparison uses & so that it doesn't short circuit and
+      # uses `variable_size_secure_compare` so that length information
+      # isn't leaked.
+      ActiveSupport::SecurityUtils.variable_size_secure_compare(name, ENV.fetch('HTTP_BASIC_AUTH_USERNAME')) &
+        ActiveSupport::SecurityUtils.variable_size_secure_compare(password, ENV.fetch('HTTP_BASIC_AUTH_PASSWORD'))
+    end
+  end
+end

--- a/app/controllers/monthly_service_metrics_controller.rb
+++ b/app/controllers/monthly_service_metrics_controller.rb
@@ -2,6 +2,8 @@ class MonthlyServiceMetricsController < ApplicationController
   before_action :load_service, only: %i(edit update)
   before_action :load_metrics, only: %i(edit update)
 
+  skip_authentication
+
   def edit; end
 
   def update

--- a/config/initializers/basic_authentication.rb
+++ b/config/initializers/basic_authentication.rb
@@ -1,7 +1,0 @@
-unless Rails.env.development? || Rails.env.test?
-  Rails.application.configure do
-    config.middleware.use Rack::Auth::Basic, 'Service Performance' do |username, password|
-      username == ENV.fetch('HTTP_BASIC_AUTH_USERNAME') && password == ENV.fetch('HTTP_BASIC_AUTH_PASSWORD')
-    end
-  end
-end


### PR DESCRIPTION
Make authentication a controller level concern.

In order to remove authentication from the data publishing form, we need to be able to override basic authentication at a controller level.