### PR TITLE
Change table refs to integers

### DIFF
--- a/app/importers/departments_importer.rb
+++ b/app/importers/departments_importer.rb
@@ -78,7 +78,7 @@ class DepartmentsImporter
       delivery_organisation = DeliveryOrganisation.where(natural_key: organisation_id).first
 
       log = ->(message, args = nil) do
-        args ||= { key: delivery_organisation.natural_key, department_code: delivery_organisation.department_code }
+        args ||= { key: delivery_organisation.natural_key, department_code: delivery_organisation.department.natural_key }
         @output.puts message % args
       end
 

--- a/app/importers/metrics_importer.rb
+++ b/app/importers/metrics_importer.rb
@@ -44,8 +44,7 @@ class MetricsImporter
     delivery_organisation = delivery_organisation(row.delivery_organisation_name)
 
     service.natural_key ||= SecureRandom.hex(2)
-    service.hostname = service.natural_key
-    service.delivery_organisation_code = delivery_organisation.natural_key
+    service.delivery_organisation_id = delivery_organisation.id
     service.start_page_url = row.service_url
     service.save!
 

--- a/app/importers/old_metrics_importer.rb
+++ b/app/importers/old_metrics_importer.rb
@@ -44,9 +44,7 @@ class OldMetricsImporter
     delivery_organisation = delivery_organisation(row.delivery_organisation_name)
 
     service.natural_key ||= SecureRandom.hex(2)
-    service.hostname = service.natural_key
-    service.delivery_organisation_code = delivery_organisation.natural_key
-    # service.department_code = delivery_organisation.department_code
+    service.delivery_organisation_id = delivery_organisation.id
     service.start_page_url = row.service_url
     service.save!
 
@@ -54,8 +52,8 @@ class OldMetricsImporter
       return if quantity == NOT_APPLICABLE
 
       klass.create!({
-        department_code: delivery_organisation.department_code,
-        delivery_organisation_code: delivery_organisation.natural_key,
+        department_id: delivery_organisation.department_id,
+        delivery_organisation_id: delivery_organisation.id,
         service_code: service.natural_key,
         starts_on: row.date.beginning_of_month,
         ends_on: row.date.end_of_month,

--- a/app/models/delivery_organisation.rb
+++ b/app/models/delivery_organisation.rb
@@ -1,6 +1,6 @@
 class DeliveryOrganisation < ApplicationRecord
-  belongs_to :department, primary_key: :natural_key, foreign_key: :department_code, optional: true
-  has_many :services, primary_key: :natural_key, foreign_key: :delivery_organisation_code
+  belongs_to :department, primary_key: :id, foreign_key: :department_id, optional: true
+  has_many :services, primary_key: :id, foreign_key: :delivery_organisation_id
 
   has_many :metrics, through: :services
 

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,5 +1,5 @@
 class Department < ApplicationRecord
-  has_many :delivery_organisations, primary_key: :natural_key, foreign_key: :department_code
+  has_many :delivery_organisations, primary_key: :id, foreign_key: :department_id
   has_many :services, through: :delivery_organisations
 
   has_many :metrics, through: :services

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,13 +1,11 @@
 class Service < ApplicationRecord
-  belongs_to :delivery_organisation, primary_key: :natural_key, foreign_key: :delivery_organisation_code
+  belongs_to :delivery_organisation, primary_key: :id, foreign_key: :delivery_organisation_id
   has_one :department, through: :delivery_organisation
 
   has_many :metrics, class_name: 'MonthlyServiceMetrics'
 
   validates_presence_of :natural_key
-  validates_presence_of :natural_key
   validates_presence_of :name
-  validates_presence_of :hostname
 
   before_create do
     self.publish_token ||= SecureRandom.hex(64)

--- a/app/serializers/service_serializer.rb
+++ b/app/serializers/service_serializer.rb
@@ -1,5 +1,5 @@
 class ServiceSerializer < ActiveModel::Serializer
-  attributes :type, :natural_key, :name, :hostname, :purpose, :how_it_works,
+  attributes :type, :natural_key, :name, :purpose, :how_it_works,
              :typical_users, :frequency_used, :duration_until_outcome,
              :start_page_url, :paper_form_url
 

--- a/db/migrate/20171114101501_remove_service_host_name.rb
+++ b/db/migrate/20171114101501_remove_service_host_name.rb
@@ -1,5 +1,9 @@
 class RemoveServiceHostName < ActiveRecord::Migration[5.1]
-  def change
+  def up
      remove_column :services, :hostname, :string
+  end
+
+  def down
+    add_column :services, :hostname, :string
   end
 end

--- a/db/migrate/20171114101501_remove_service_host_name.rb
+++ b/db/migrate/20171114101501_remove_service_host_name.rb
@@ -1,0 +1,5 @@
+class RemoveServiceHostName < ActiveRecord::Migration[5.1]
+  def change
+     remove_column :services, :hostname, :string
+  end
+end

--- a/db/migrate/20171114102541_change_delivery_org_reference.rb
+++ b/db/migrate/20171114102541_change_delivery_org_reference.rb
@@ -3,8 +3,7 @@ class ChangeDeliveryOrgReference < ActiveRecord::Migration[5.1]
     add_column :services, :delivery_organisation_id, :integer, null: true
     add_foreign_key :services, :delivery_organisations, column: :delivery_organisation_id, primary_key: :id
 
-    sql = 'update services set delivery_organisation_id=(select id from delivery_organisations D where D.natural_key="services".delivery_organisation_code);'
-    ActiveRecord::Base.connection.execute(sql)
+    execute 'update services set delivery_organisation_id=(select id from delivery_organisations D where D.natural_key="services".delivery_organisation_code);'
 
     change_column :services, :delivery_organisation_id, :integer, null: false
     remove_column :services, :delivery_organisation_code, :string, null: false

--- a/db/migrate/20171114102541_change_delivery_org_reference.rb
+++ b/db/migrate/20171114102541_change_delivery_org_reference.rb
@@ -1,0 +1,13 @@
+class ChangeDeliveryOrgReference < ActiveRecord::Migration[5.1]
+  def change
+    add_column :services, :delivery_organisation_id, :integer, null: true
+    add_foreign_key :services, :delivery_organisations, column: :delivery_organisation_id, primary_key: :id
+
+    sql = 'update services set delivery_organisation_id=(select id from delivery_organisations D where D.natural_key="services".delivery_organisation_code);'
+    ActiveRecord::Base.connection.execute(sql)
+
+    change_column :services, :delivery_organisation_id, :integer, null: false
+    remove_column :services, :delivery_organisation_code, :string, null: false
+  end
+end
+

--- a/db/migrate/20171114102541_change_delivery_org_reference.rb
+++ b/db/migrate/20171114102541_change_delivery_org_reference.rb
@@ -1,5 +1,5 @@
 class ChangeDeliveryOrgReference < ActiveRecord::Migration[5.1]
-  def change
+  def up
     add_column :services, :delivery_organisation_id, :integer, null: true
     add_foreign_key :services, :delivery_organisations, column: :delivery_organisation_id, primary_key: :id
 
@@ -8,6 +8,16 @@ class ChangeDeliveryOrgReference < ActiveRecord::Migration[5.1]
 
     change_column :services, :delivery_organisation_id, :integer, null: false
     remove_column :services, :delivery_organisation_code, :string, null: false
+  end
+
+  def down
+    add_column :services, :delivery_organisation_code, :string, null: true
+    add_foreign_key :services, :delivery_organisations, column: :delivery_organisation_code, primary_key: :natural_key
+
+    execute 'update services set delivery_organisation_code=(select natural_key from delivery_organisations D where D.id="services".delivery_organisation_id);'
+
+    change_column :services, :delivery_organisation_code, :string, null: false
+    remove_column :services, :delivery_organisation_id, :integer, null: true
   end
 end
 

--- a/db/migrate/20171114111428_change_department_reference.rb
+++ b/db/migrate/20171114111428_change_department_reference.rb
@@ -1,5 +1,5 @@
 class ChangeDepartmentReference < ActiveRecord::Migration[5.1]
-  def change
+  def up
     add_column :delivery_organisations, :department_id, :integer, null: true
     add_foreign_key :delivery_organisations, :departments, column: :department_id, primary_key: :id
 
@@ -7,5 +7,14 @@ class ChangeDepartmentReference < ActiveRecord::Migration[5.1]
     ActiveRecord::Base.connection.execute(sql)
 
     remove_column :delivery_organisations, :department_code, :string, null: false
+  end
+
+  def down
+    add_column :delivery_organisations, :department_code, :string, null: true
+
+    execute 'update delivery_organisations set department_code=(select natural_key from departments D where D.id="delivery_organisations".department_id);'
+
+    change_column :delivery_organisations, :department_code, :string, null: false
+    remove_column :delivery_organisations, :department_id, :integer, null: true
   end
 end

--- a/db/migrate/20171114111428_change_department_reference.rb
+++ b/db/migrate/20171114111428_change_department_reference.rb
@@ -1,0 +1,11 @@
+class ChangeDepartmentReference < ActiveRecord::Migration[5.1]
+  def change
+    add_column :delivery_organisations, :department_id, :integer, null: true
+    add_foreign_key :delivery_organisations, :departments, column: :department_id, primary_key: :id
+
+    sql = 'update delivery_organisations set department_id=(select id from departments D where D.natural_key="delivery_organisations".department_code);'
+    ActiveRecord::Base.connection.execute(sql)
+
+    remove_column :delivery_organisations, :department_code, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,9 +64,9 @@ ActiveRecord::Schema.define(version: 20171110112018) do
     t.string "natural_key", null: false
     t.string "name", null: false
     t.string "website", null: false
-    t.string "department_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "department_id"
     t.index ["natural_key"], name: "index_delivery_organisations_on_natural_key", unique: true
   end
 
@@ -103,10 +103,8 @@ ActiveRecord::Schema.define(version: 20171110112018) do
   create_table "services", id: :serial, force: :cascade do |t|
     t.string "natural_key", null: false
     t.string "name", null: false
-    t.string "hostname", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "delivery_organisation_code"
     t.text "purpose"
     t.text "how_it_works"
     t.text "typical_users"
@@ -128,6 +126,7 @@ ActiveRecord::Schema.define(version: 20171110112018) do
     t.boolean "calls_received_challenge_decision_applicable", default: true
     t.boolean "calls_received_other_applicable", default: true
     t.boolean "calls_received_perform_transaction_applicable", default: true
+    t.integer "delivery_organisation_id", null: false
     t.index ["natural_key"], name: "index_services_on_natural_key", unique: true
     t.index ["publish_token"], name: "index_services_on_publish_token", unique: true
   end
@@ -179,9 +178,9 @@ ActiveRecord::Schema.define(version: 20171110112018) do
   add_foreign_key "calls_received_metrics", "delivery_organisations", column: "delivery_organisation_code", primary_key: "natural_key"
   add_foreign_key "calls_received_metrics", "departments", column: "department_code", primary_key: "natural_key"
   add_foreign_key "calls_received_metrics", "services", column: "service_code", primary_key: "natural_key"
-  add_foreign_key "delivery_organisations", "departments", column: "department_code", primary_key: "natural_key"
+  add_foreign_key "delivery_organisations", "departments"
   add_foreign_key "monthly_service_metrics", "services"
-  add_foreign_key "services", "delivery_organisations", column: "delivery_organisation_code", primary_key: "natural_key"
+  add_foreign_key "services", "delivery_organisations"
   add_foreign_key "transactions_received_metrics", "delivery_organisations", column: "delivery_organisation_code", primary_key: "natural_key"
   add_foreign_key "transactions_received_metrics", "departments", column: "department_code", primary_key: "natural_key"
   add_foreign_key "transactions_received_metrics", "services", column: "service_code", primary_key: "natural_key"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171110112018) do
+ActiveRecord::Schema.define(version: 20171114111428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,56 +10,65 @@ ActiveRecord::Base.transaction do
   Department.create!(natural_key: 'D0006', name: 'Department for Education', website: 'http://example.com/department-for-education')
   Department.create!(natural_key: 'D0007', name: 'Department for Business, Energy & Industrial Strategy', website: 'http://example.com/department-for-business-energy-and-industrial-strategy')
 
-  # delivery organisations
-  DeliveryOrganisation.create!(department_code: 'D0001', natural_key: 'D0001', name: 'Department for Environment Food & Rural Affairs', website: 'http://example.com/department-for-environment-food-and-rural-affairs')
-  DeliveryOrganisation.create!(department_code: 'D0002', natural_key: 'D0002', name: 'Department for Transport', website: 'http://example.com/department-for-transport')
-  DeliveryOrganisation.create!(department_code: 'D0003', natural_key: 'D0003', name: 'Department of Health', website: 'http://example.com/department-of-health')
-  DeliveryOrganisation.create!(department_code: 'D0004', natural_key: 'D0004', name: 'HM Revenue & Customs', website: 'http://example.com/hm-revenue-and-customs')
-  DeliveryOrganisation.create!(department_code: 'D0005', natural_key: 'D0005', name: 'Ministry of Justice', website: 'http://example.com/ministry-of-justice')
-  DeliveryOrganisation.create!(department_code: 'D0006', natural_key: 'D0006', name: 'Department for Education', website: 'http://example.com/department-for-education')
-  DeliveryOrganisation.create!(department_code: 'D0007', natural_key: 'D0007', name: 'Department for Business, Energy & Industrial Strategy', website: 'http://example.com/department-for-business-energy-and-industrial-strategy')
+  def get_department(code)
+    Department.where(natural_key: code).first.id
+  end
 
-  DeliveryOrganisation.create!(department_code: 'D0001', natural_key: '01', name: 'Environment Agency', website: 'http://example.com/environment-agency')
-  DeliveryOrganisation.create!(department_code: 'D0003', natural_key: '02', name: 'NHS Blood and Transplant', website: 'http://example.com/nhs-blood-and-transplant')
-  DeliveryOrganisation.create!(department_code: 'D0002', natural_key: '03', name: 'Driver and Vehicle Licensing Agency', website: 'http://example.com/driver-and-vehicle-licensing-agency')
-  DeliveryOrganisation.create!(department_code: 'D0002', natural_key: '04', name: 'Driver and Vehicle Standards Agency', website: 'http://example.com/driver-and-vehicle-standards-agency')
-  DeliveryOrganisation.create!(department_code: 'D0005', natural_key: '06', name: 'HM Courts & Tribunals Service', website: 'http://example.com/hm-courts-and-tribunals-service')
-  DeliveryOrganisation.create!(department_code: 'D0003', natural_key: '09', name: 'NHS England', website: 'http://example.com/nhs-england')
-  DeliveryOrganisation.create!(department_code: 'D0006', natural_key: '12', name: 'Skills Funding Agency', website: 'http://example.com/skills-funding-agency')
-  DeliveryOrganisation.create!(department_code: 'D0006', natural_key: '13', name: 'Student Loans Company', website: 'http://example.com/student-loans-company')
+  # delivery organisations
+  DeliveryOrganisation.create!(department_id: get_department('D0001'), natural_key: 'D0001', name: 'Department for Environment Food & Rural Affairs', website: 'http://example.com/department-for-environment-food-and-rural-affairs')
+  DeliveryOrganisation.create!(department_id: get_department('D0002'), natural_key: 'D0002', name: 'Department for Transport', website: 'http://example.com/department-for-transport')
+  DeliveryOrganisation.create!(department_id: get_department('D0003'), natural_key: 'D0003', name: 'Department of Health', website: 'http://example.com/department-of-health')
+  DeliveryOrganisation.create!(department_id: get_department('D0004'), natural_key: 'D0004', name: 'HM Revenue & Customs', website: 'http://example.com/hm-revenue-and-customs')
+  DeliveryOrganisation.create!(department_id: get_department('D0005'), natural_key: 'D0005', name: 'Ministry of Justice', website: 'http://example.com/ministry-of-justice')
+  DeliveryOrganisation.create!(department_id: get_department('D0006'), natural_key: 'D0006', name: 'Department for Education', website: 'http://example.com/department-for-education')
+  DeliveryOrganisation.create!(department_id: get_department('D0007'), natural_key: 'D0007', name: 'Department for Business, Energy & Industrial Strategy', website: 'http://example.com/department-for-business-energy-and-industrial-strategy')
+
+  DeliveryOrganisation.create!(department_id: get_department('D0001'), natural_key: '01', name: 'Environment Agency', website: 'http://example.com/environment-agency')
+  DeliveryOrganisation.create!(department_id: get_department('D0003'), natural_key: '02', name: 'NHS Blood and Transplant', website: 'http://example.com/nhs-blood-and-transplant')
+  DeliveryOrganisation.create!(department_id: get_department('D0002'), natural_key: '03', name: 'Driver and Vehicle Licensing Agency', website: 'http://example.com/driver-and-vehicle-licensing-agency')
+  DeliveryOrganisation.create!(department_id: get_department('D0002'), natural_key: '04', name: 'Driver and Vehicle Standards Agency', website: 'http://example.com/driver-and-vehicle-standards-agency')
+  DeliveryOrganisation.create!(department_id: get_department('D0005'), natural_key: '06', name: 'HM Courts & Tribunals Service', website: 'http://example.com/hm-courts-and-tribunals-service')
+  DeliveryOrganisation.create!(department_id: get_department('D0003'), natural_key: '09', name: 'NHS England', website: 'http://example.com/nhs-england')
+  DeliveryOrganisation.create!(department_id: get_department('D0006'), natural_key: '12', name: 'Skills Funding Agency', website: 'http://example.com/skills-funding-agency')
+  DeliveryOrganisation.create!(department_id: get_department('D0006'), natural_key: '13', name: 'Student Loans Company', website: 'http://example.com/student-loans-company')
+
+  def get_delivery_org(code)
+    DeliveryOrganisation.where(natural_key: code).first.id
+  end
+
 
   # services
-  Service.create!(delivery_organisation_code: '01', natural_key: '01', name: 'Buy a fishing rod licence', hostname: 'buy-a-fishing-licence')
-  Service.create!(delivery_organisation_code: '03', natural_key: '02', name: 'Apply for a provisional driving license', hostname: 'apply-for-a-provisional-driving-license')
-  Service.create!(delivery_organisation_code: '02', natural_key: '03', name: 'Give blood', hostname: 'give-blood')
-  Service.create!(delivery_organisation_code: '12', natural_key: '04', name: 'Search and apply for apprenticeship vacancies in England', hostname: 'search-and-apply-for-apprenticeship-vacancies-in-england')
-  Service.create!(delivery_organisation_code: '12', natural_key: '05', name: 'Create a unique learner number', hostname: 'create-a-unique-learner-number')
-  Service.create!(delivery_organisation_code: '12', natural_key: '06', name: 'Post an apprenticeship vacancy', hostname: 'post-an-apprenticeship-vacancy')
-  Service.create!(delivery_organisation_code: '13', natural_key: '07', name: 'Apply for student finance', hostname: 'apply-for-student-finance')
-  Service.create!(delivery_organisation_code: '13', natural_key: '08', name: 'Repay student loan voluntarily', hostname: 'repay-student-loan-voluntarily')
-  Service.create!(delivery_organisation_code: '13', natural_key: '09', name: 'Apply for disabled student allowance', hostname: 'apply-for-disabled-student-allowance')
-  Service.create!(delivery_organisation_code: '13', natural_key: '10', name: 'Apply for part time study support', hostname: 'apply-for-part-time-study-support')
-  Service.create!(delivery_organisation_code: '04', natural_key: '11', name: 'Pay the Dartford Crossing Charge', hostname: 'pay-the-dartford-crossing-charge')
-  Service.create!(delivery_organisation_code: '03', natural_key: '12', name: 'Tax your vehicle', hostname: 'tax-your-vehicle')
-  Service.create!(delivery_organisation_code: '03', natural_key: '13', name: 'Make a change to a vehicle registration certificate', hostname: 'make-a-change-to-a-vehicle-registration-certificate')
-  Service.create!(delivery_organisation_code: '03', natural_key: '14', name: "Check someone's driving information", hostname: 'check-someones-driving-information')
-  Service.create!(delivery_organisation_code: '03', natural_key: '15', name: "Tell DVLA you've sold, transferred or bought a vehicle", hostname: 'tell-dvla-youve-sold-transferred-or-bought-a-vehicle')
-  Service.create!(delivery_organisation_code: '04', natural_key: '16', name: 'Book a driving theory test', hostname: 'book-a-driving-theory-test')
-  Service.create!(delivery_organisation_code: '04', natural_key: '17', name: 'Book a practical driving test', hostname: 'book-a-practical-driving-test')
-  Service.create!(delivery_organisation_code: '04', natural_key: '18', name: 'Change a practical driving test booking', hostname: 'change-a-practical-driving-test-booking')
-  Service.create!(delivery_organisation_code: 'D0004', natural_key: '19', name: 'State pension: existing claims', hostname: 'state-pension-existing-claims')
-  Service.create!(delivery_organisation_code: 'D0004', natural_key: '20', name: 'Disability allowance: existing claims', hostname: 'disability-allowance-existing-claims')
-  Service.create!(delivery_organisation_code: 'D0004', natural_key: '21', name: 'Education support allowance: existing claims', hostname: 'education-support-allowance-existing-claims')
-  Service.create!(delivery_organisation_code: 'D0004', natural_key: '22', name: 'Pension credit: existing claims', hostname: 'pension-credit-existing-claims')
-  Service.create!(delivery_organisation_code: 'D0004', natural_key: '23', name: 'Education support allowance: new claims', hostname: 'education-support-allowance-new-claims')
-  Service.create!(delivery_organisation_code: '02', natural_key: '24', name: 'Changes to organ donor register', hostname: 'changes-to-organ-donor-register')
-  Service.create!(delivery_organisation_code: '02', natural_key: '25', name: 'Register to donate organs', hostname: 'register-to-donate-organs')
-  Service.create!(delivery_organisation_code: '09', natural_key: '26', name: 'NHS e-referrals', hostname: 'nhs-e-referrals')
-  Service.create!(delivery_organisation_code: 'D0005', natural_key: '27', name: 'PAYE transactions', hostname: 'paye-transactions')
-  Service.create!(delivery_organisation_code: 'D0005', natural_key: '28', name: 'Customs transactions', hostname: 'customs-transactions')
-  Service.create!(delivery_organisation_code: 'D0005', natural_key: '29', name: 'VAT transactions', hostname: 'vat-transactions')
-  Service.create!(delivery_organisation_code: 'D0005', natural_key: '30', name: 'Register for and file your Self Assessment tax return', hostname: 'register-for-and-file-your-self-assessment-tax-return')
-  Service.create!(delivery_organisation_code: 'D0005', natural_key: '44', name: 'Stamp Duty Reserve Tax', hostname: 'stamp-duty-reserve-tax')
+  Service.create!(delivery_organisation_id: get_delivery_org('01'), natural_key: '01', name: 'Buy a fishing rod licence')
+  Service.create!(delivery_organisation_id: get_delivery_org('03'), natural_key: '02', name: 'Apply for a provisional driving license')
+  Service.create!(delivery_organisation_id: get_delivery_org('02'), natural_key: '03', name: 'Give blood')
+  Service.create!(delivery_organisation_id: get_delivery_org('12'), natural_key: '04', name: 'Search and apply for apprenticeship vacancies in England')
+  Service.create!(delivery_organisation_id: get_delivery_org('12'), natural_key: '05', name: 'Create a unique learner number')
+  Service.create!(delivery_organisation_id: get_delivery_org('12'), natural_key: '06', name: 'Post an apprenticeship vacancy')
+  Service.create!(delivery_organisation_id: get_delivery_org('13'), natural_key: '07', name: 'Apply for student finance')
+  Service.create!(delivery_organisation_id: get_delivery_org('13'), natural_key: '08', name: 'Repay student loan voluntarily')
+  Service.create!(delivery_organisation_id: get_delivery_org('13'), natural_key: '09', name: 'Apply for disabled student allowance')
+  Service.create!(delivery_organisation_id: get_delivery_org('13'), natural_key: '10', name: 'Apply for part time study support')
+  Service.create!(delivery_organisation_id: get_delivery_org('04'), natural_key: '11', name: 'Pay the Dartford Crossing Charge')
+  Service.create!(delivery_organisation_id: get_delivery_org('03'), natural_key: '12', name: 'Tax your vehicle')
+  Service.create!(delivery_organisation_id: get_delivery_org('03'), natural_key: '13', name: 'Make a change to a vehicle registration certificate')
+  Service.create!(delivery_organisation_id: get_delivery_org('03'), natural_key: '14', name: "Check someone's driving information")
+  Service.create!(delivery_organisation_id: get_delivery_org('03'), natural_key: '15', name: "Tell DVLA you've sold, transferred or bought a vehicle")
+  Service.create!(delivery_organisation_id: get_delivery_org('04'), natural_key: '16', name: 'Book a driving theory test')
+  Service.create!(delivery_organisation_id: get_delivery_org('04'), natural_key: '17', name: 'Book a practical driving test')
+  Service.create!(delivery_organisation_id: get_delivery_org('04'), natural_key: '18', name: 'Change a practical driving test booking')
+  Service.create!(delivery_organisation_id: get_delivery_org('D0004'), natural_key: '19', name: 'State pension: existing claims')
+  Service.create!(delivery_organisation_id: get_delivery_org('D0004'), natural_key: '20', name: 'Disability allowance: existing claims')
+  Service.create!(delivery_organisation_id: get_delivery_org('D0004'), natural_key: '21', name: 'Education support allowance: existing claims')
+  Service.create!(delivery_organisation_id: get_delivery_org('D0004'), natural_key: '22', name: 'Pension credit: existing claims')
+  Service.create!(delivery_organisation_id: get_delivery_org('D0004'), natural_key: '23', name: 'Education support allowance: new claims')
+  Service.create!(delivery_organisation_id: get_delivery_org('02'), natural_key: '24', name: 'Changes to organ donor register')
+  Service.create!(delivery_organisation_id: get_delivery_org('02'), natural_key: '25', name: 'Register to donate organs')
+  Service.create!(delivery_organisation_id: get_delivery_org('09'), natural_key: '26', name: 'NHS e-referrals')
+  Service.create!(delivery_organisation_id: get_delivery_org('D0005'), natural_key: '27', name: 'PAYE transactions')
+  Service.create!(delivery_organisation_id: get_delivery_org('D0005'), natural_key: '28', name: 'Customs transactions')
+  Service.create!(delivery_organisation_id: get_delivery_org('D0005'), natural_key: '29', name: 'VAT transactions')
+  Service.create!(delivery_organisation_id: get_delivery_org('D0005'), natural_key: '30', name: 'Register for and file your Self Assessment tax return')
+  Service.create!(delivery_organisation_id: get_delivery_org('D0005'), natural_key: '44', name: 'Stamp Duty Reserve Tax')
 
   [
     { service_code: '01', starts_on: '2017-05-01', ends_on: '2017-05-31', channel: 'online', quantity: 1000032 },
@@ -123,7 +132,7 @@ ActiveRecord::Base.transaction do
 
     TransactionsReceivedMetric.create!(
       department_code: service.department.natural_key,
-      delivery_organisation_code: service.delivery_organisation_code,
+      delivery_organisation_code: service.delivery_organisation.natural_key,
       service_code: service.natural_key,
       starts_on: transaction_received_metric[:starts_on],
       ends_on: Date.parse(transaction_received_metric[:ends_on]) + 1.day,
@@ -188,7 +197,7 @@ ActiveRecord::Base.transaction do
 
     TransactionsWithOutcomeMetric.create!(
       department_code: service.department.natural_key,
-      delivery_organisation_code: service.delivery_organisation_code,
+      delivery_organisation_code: service.delivery_organisation.natural_key,
       service_code: service.natural_key,
       starts_on: transaction_with_outcome_metric[:starts_on],
       ends_on: Date.parse(transaction_with_outcome_metric[:ends_on]) + 1.day,
@@ -207,7 +216,7 @@ ActiveRecord::Base.transaction do
 
     CallsReceivedMetric.create!(
       department_code: service.department.natural_key,
-      delivery_organisation_code: service.delivery_organisation_code,
+      delivery_organisation_code: service.delivery_organisation.natural_key,
       service_code: service.natural_key,
       starts_on: calls_received_metric[:starts_on],
       ends_on: Date.parse(calls_received_metric[:ends_on]) + 1.day,

--- a/spec/factories/services_factory.rb
+++ b/spec/factories/services_factory.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :service do
     sequence(:natural_key) { |n| '%04d' % n }
     name 'Renew Service'
-    hostname 'renew-service'
 
     delivery_organisation
   end

--- a/spec/models/delivery_organisation_spec.rb
+++ b/spec/models/delivery_organisation_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe DeliveryOrganisation, type: :model do
   describe '#services' do
     it 'returns a scope of services, which belong to the delivery organisation' do
       delivery_organisation = FactoryGirl.create(:delivery_organisation)
-      service1 = FactoryGirl.create(:service, delivery_organisation_code: delivery_organisation.natural_key)
-      service2 = FactoryGirl.create(:service, delivery_organisation_code: delivery_organisation.natural_key)
+      service1 = FactoryGirl.create(:service, delivery_organisation_id: delivery_organisation.id)
+      service2 = FactoryGirl.create(:service, delivery_organisation_id: delivery_organisation.id)
 
       expect(delivery_organisation.services.to_a).to match_array([service1, service2])
     end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -15,11 +15,6 @@ RSpec.describe Service, type: :model do
       service.name = ''
       expect(service).to_not be_valid
     end
-
-    it 'requires a hostname' do
-      service.hostname = ''
-      expect(service).to_not be_valid
-    end
   end
 
   describe '#services' do


### PR DESCRIPTION
The references between service and delivery org, and delivery org and
department where specified using the natural_keys, and this PR changes
them to use integer ids instead.