### PR TITLE
Change Next Metrics Due Date

### DIFF
--- a/app/models/monthly_service_metrics.rb
+++ b/app/models/monthly_service_metrics.rb
@@ -38,7 +38,7 @@ class MonthlyServiceMetrics < ApplicationRecord
 
   def next_metrics_due_date
     if month
-      month.date + 1.month
+      month.date + 2.months
     end
   end
 

--- a/spec/features/submitting_monthly_service_metrics_spec.rb
+++ b/spec/features/submitting_monthly_service_metrics_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'submitting monthly service metrics' do
 
     expect(page).to have_text('Upload successful')
     expect(page).to have_text('Thank you for providing your monthly data. It will be published on 1 November 2017.')
-    expect(page).to have_text('You will next be asked to provide data on 1 October.')
+    expect(page).to have_text('You will next be asked to provide data on 1 November.')
   end
 
   private

--- a/spec/models/monthly_service_metrics_spec.rb
+++ b/spec/models/monthly_service_metrics_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe MonthlyServiceMetrics, type: :model do
 
     it 'returns the first of the month, 2 months from the given month' do
       metrics = FactoryGirl.build(:monthly_service_metrics, month: YearMonth.new(2017, 11))
-      expect(metrics.next_metrics_due_date).to eq(Date.new(2017, 12, 1))
+      expect(metrics.next_metrics_due_date).to eq(Date.new(2018, 1, 1))
     end
   end
 end


### PR DESCRIPTION
We ask for a month's metrics on the 1st, after the month is over (i.e.
we ask for October's metrics, in 1st November), therefore we'll next ask
(for November's metrics) on 1st December – 2 months from this month.