### PR TITLE
Adds an owner to each service.

### DIFF
--- a/app/admin/service.rb
+++ b/app/admin/service.rb
@@ -5,6 +5,9 @@ ActiveAdmin.register Service do
     column :name
     column :delivery_organisation
     column :department
+    column "Owner" do |service|
+      service.owner.email if service.owner
+    end
     actions
   end
 
@@ -12,6 +15,9 @@ ActiveAdmin.register Service do
     attributes_table do
       row :name
       row :delivery_organisation
+      row "Owner" do |service|
+        service.owner.email if service.owner
+      end
       row :natural_key
       row :created_at
       row :updated_at
@@ -67,7 +73,7 @@ ActiveAdmin.register Service do
     end
   end
 
-  permit_params :id, :natural_key, :name,
+  permit_params :id, :natural_key, :name, :owner_id,
                 :created_at, :updated_at, :delivery_organisation_id,
                 :purpose, :how_it_works, :typical_users, :frequency_used,
                 :duration_until_outcome, :start_page_url, :paper_form_url,

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,0 +1,46 @@
+ActiveAdmin.register User do
+  permit_params :email, :password, :password_confirmation
+
+  index do
+    selectable_column
+    id_column
+    column :email
+    column :current_sign_in_at
+    column :sign_in_count
+    column :created_at
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :email
+      row :current_sign_in_at
+      row :sign_in_count
+      row :created_at
+    end
+
+    panel "Services" do
+      user.services.each do |svc|
+        li link_to(svc.name, admin_service_path(svc))
+      end
+    end
+  end
+
+  filter :email
+  filter :current_sign_in_at
+  filter :sign_in_count
+  filter :created_at
+
+  form do |f|
+    # Currently we don't expect users to log in, we are just using their email
+    # address and so we set their password to something we don't know.
+    passwd = Devise.friendly_token.first(32)
+
+    f.inputs do
+      f.input :email
+      f.input :password, input_html: { value: f.object.password ||= passwd }
+      f.input :password_confirmation, input_html: { value: f.object.password_confirmation ||= passwd }
+    end
+    f.actions
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,4 +1,5 @@
 class Service < ApplicationRecord
+  belongs_to :owner, primary_key: :id, foreign_key: :owner_id, class_name: "User", optional: true
   belongs_to :delivery_organisation, primary_key: :id, foreign_key: :delivery_organisation_id
   has_one :department, through: :delivery_organisation
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :lockable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  has_many :services, foreign_key: :owner_id
+
+  def to_s
+    email
+  end
 end

--- a/db/migrate/20171117163006_add_owner_to_service.rb
+++ b/db/migrate/20171117163006_add_owner_to_service.rb
@@ -1,0 +1,6 @@
+class AddOwnerToService < ActiveRecord::Migration[5.1]
+  def change
+    add_column :services, :owner_id, :integer, null: true
+    add_foreign_key :services, :users, column: :owner_id, primary_key: :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115093509) do
+ActiveRecord::Schema.define(version: 20171117163006) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 20171115093509) do
     t.boolean "calls_received_other_applicable", default: true
     t.boolean "calls_received_perform_transaction_applicable", default: true
     t.integer "delivery_organisation_id", null: false
+    t.integer "owner_id"
     t.index ["natural_key"], name: "index_services_on_natural_key", unique: true
     t.index ["publish_token"], name: "index_services_on_publish_token", unique: true
   end
@@ -140,4 +141,5 @@ ActiveRecord::Schema.define(version: 20171115093509) do
   add_foreign_key "delivery_organisations", "departments"
   add_foreign_key "monthly_service_metrics", "services"
   add_foreign_key "services", "delivery_organisations"
+  add_foreign_key "services", "users", column: "owner_id"
 end


### PR DESCRIPTION
Allows a service to have an owner so that we can (later) more easily
give a magic link to the person who owns a service.

Adds the User to admin, showing the services they own where
appropriate.  As we don't expect users to log in with these
accounts just yet, the passwords default to a long string
when user accounts are created.