### PR TITLE
Adds recently added services to dashboard, as well as update-dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Government Service Data
 
-This is the API for interacting with Service Performance data. This is currently consumed by the the [`gsd-view-data`](https://github.com/alphagov/gsd-view-data) application.
+This is the API for interacting with Service Performance data. This is currently consumed by the [`gsd-view-data`](https://github.com/alphagov/gsd-view-data) application.
 
 It also contains the publishing workflow for collecting metrics from Services, and an admin interface to coordinate data collection.
 

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -2,13 +2,43 @@ ActiveAdmin.register_page "Dashboard" do
   menu priority: 1, label: proc { I18n.t("active_admin.dashboard") }
 
   content title: proc { I18n.t("active_admin.dashboard") } do
+    h2 "Recently added"
     columns do
       column do
         panel "Recently added metrics" do
-          ul do
+          table do
+            tr do
+              th "Month"
+              th "Delivery Organisation"
+              th "Service"
+              th "Updated"
+            end
             MonthlyServiceMetrics.last(10).reverse.map do |metric|
-              k = "#{metric.month} - #{metric.service.name}"
-              li link_to(k, admin_monthly_service_metric_path(metric))
+              tr do
+                td metric.month
+                td metric.service.delivery_organisation.name
+                td link_to(metric.service.name, admin_monthly_service_metric_path(metric))
+                td metric.updated_at.to_date
+              end
+            end
+          end
+        end
+      end
+
+      column do
+        panel "Recently added services" do
+          table do
+            tr do
+              th "Delivery Organisation"
+              th "Added"
+              th "Service"
+            end
+            Service.last(10).reverse.map do |svc|
+              tr do
+                td svc.delivery_organisation.name
+                td svc.created_at.to_date
+                td link_to(svc.name, admin_service_path(svc))
+              end
             end
           end
         end

--- a/db/migrate/20171121104151_add_metrics_timestamps.rb
+++ b/db/migrate/20171121104151_add_metrics_timestamps.rb
@@ -1,0 +1,16 @@
+class AddMetricsTimestamps < ActiveRecord::Migration[5.1]
+  def up
+    add_column :monthly_service_metrics, :created_at, :datetime, null: true
+    add_column :monthly_service_metrics, :updated_at, :datetime, null: true
+
+    MonthlyServiceMetrics.update_all created_at: Time.now, updated_at: Time.now
+
+    change_column :monthly_service_metrics, :created_at, :datetime, null: false
+    change_column :monthly_service_metrics, :updated_at, :datetime, null: false
+  end
+
+  def down
+    remove_column :monthly_service_metrics, :created_at, :datetime, null: false
+    remove_column :monthly_service_metrics, :updated_at, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171117163006) do
+ActiveRecord::Schema.define(version: 20171121104151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,8 @@ ActiveRecord::Schema.define(version: 20171117163006) do
     t.bigint "calls_received_other"
     t.bigint "calls_received_perform_transaction"
     t.boolean "published", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index "service_id, date_trunc('month'::text, (month)::timestamp without time zone)", name: "unique_monthly_service_metrics", unique: true
     t.index ["service_id"], name: "index_monthly_service_metrics_on_service_id"
   end


### PR DESCRIPTION
Adds recently added services, and shows when they were added.  For monthly
service metrics, it now shows the updated date. Because of the migration,
they're all defaulting to today until there are actual changes.