### PR TITLE
Specify natural_key for finder in admin

### DIFF
--- a/app/admin/delivery_organisation.rb
+++ b/app/admin/delivery_organisation.rb
@@ -1,6 +1,10 @@
 ActiveAdmin.register DeliveryOrganisation do
   includes :department
 
+  controller do
+    defaults finder: :find_by_natural_key
+  end
+
   permit_params :natural_key, :name, :website, :department_id
 
   index do

--- a/app/admin/department.rb
+++ b/app/admin/department.rb
@@ -1,6 +1,10 @@
 ActiveAdmin.register Department do
   permit_params :natural_key, :name, :website
 
+  controller do
+    defaults finder: :find_by_natural_key
+  end
+
   index do
     column :natural_key
     column :name

--- a/app/admin/service.rb
+++ b/app/admin/service.rb
@@ -1,6 +1,10 @@
 ActiveAdmin.register Service do
   includes :department, :delivery_organisation
 
+  controller do
+    defaults finder: :find_by_natural_key
+  end
+
   index do
     selectable_column
     column :name


### PR DESCRIPTION
Forces the admin to use the natural_key to lookup services, departments and delivery_organisations to match the changed to_param for those objects.